### PR TITLE
Fix ClAP installer issues (POSS-177, POSS-178)

### DIFF
--- a/setup/generate_mcp_config.py
+++ b/setup/generate_mcp_config.py
@@ -179,19 +179,8 @@ def generate_mcp_servers_config() -> Dict[str, Any]:
             "env": {}
         }
     
-    # Filesystem MCP (built-in)
-    mcp_servers['filesystem'] = {
-        "type": "stdio",
-        "command": "npx",
-        "args": ["@modelcontextprotocol/server-filesystem", str(home)]
-    }
-    
-    # Super Shell MCP (for system commands)
-    mcp_servers['super-shell'] = {
-        "type": "stdio",
-        "command": "npx",
-        "args": ["@mattpearce/mcp-server-super-shell"]
-    }
+    # Note: Removed filesystem and super-shell MCP servers (POSS-177)
+    # Claude Code has built-in file and command tools that make these redundant
     
     return mcp_servers
 

--- a/setup/insert_mcp_config.py
+++ b/setup/insert_mcp_config.py
@@ -36,7 +36,7 @@ def insert_mcp_config_to_claude_json(mcp_config: dict, claude_json_path: Path) -
         # Create backup
         backup_file(claude_json_path)
         
-        # Insert MCP servers
+        # Insert MCP servers (replaces any existing to fix outdated paths - POSS-177)
         claude_config['projects'][project_path]['mcpServers'] = mcp_config
         
         # Write back
@@ -61,7 +61,7 @@ def insert_mcp_config_to_desktop(mcp_config: dict, desktop_config_path: Path) ->
         else:
             desktop_config = {}
         
-        # Insert MCP servers
+        # Insert MCP servers (replaces any existing to fix outdated paths - POSS-177)
         desktop_config['mcpServers'] = mcp_config
         
         # Write

--- a/setup/setup_clap_deployment.sh
+++ b/setup/setup_clap_deployment.sh
@@ -1252,19 +1252,21 @@ fi
 mkdir -p "$CLAP_DIR/data"
 echo "   ✅ data/ directory ready for runtime files"
 
-# Initialize channel_state.json if it doesn't exist (POSS-79)
+# Initialize channel_state.json if it doesn't exist (POSS-79, POSS-178)
 if [[ ! -f "$CLAP_DIR/data/channel_state.json" ]]; then
     echo "   Creating initial channel_state.json..."
     cat > "$CLAP_DIR/data/channel_state.json" <<'EOF'
 {
-  "1383848195997700231": {  
-    "name": "#general",
-    "server_id": "1383848194881884262",
-    "last_message_id": null,
-    "unread_count": 0,
-    "last_reset_time": null,
-    "is_unread": false
-  }
+  "channels": {
+    "general": {
+      "id": "1383848195997700231",
+      "server_id": "1383848194881884262",
+      "last_message_id": null,
+      "last_read_message_id": null,
+      "updated_at": null
+    }
+  },
+  "last_check": null
 }
 EOF
     echo "   ✅ Initial channel state created"


### PR DESCRIPTION
## Summary
- Fixed channel_state.json format to match new Discord utilities
- Removed unnecessary MCP servers that conflict with Claude Code built-in tools
- Clarified config replacement behavior to fix outdated path issues

## Fixes
- Resolves POSS-178: ClAP installer creates channel_state.json with outdated format
- Resolves POSS-177: ClAP installer configures unnecessary MCP servers and copies outdated paths

## Changes

### channel_state.json Format Update (POSS-178)
The installer now creates the correct format expected by Discord utilities:
- Added `channels` wrapper object with channel names as keys
- Updated field names to match current implementation
- Removed deprecated fields like `unread_count` and `is_unread`

### MCP Server Configuration (POSS-177)
- Removed `filesystem` MCP server (redundant with Claude Code's built-in file tools)
- Removed `super-shell` MCP server (redundant with Claude Code's built-in Bash tool)
- Added comments clarifying that config replacement handles outdated paths automatically

## Test plan
- [ ] Test installer on fresh system to verify channel_state.json format
- [ ] Verify only essential MCP servers are configured
- [ ] Test reinstall scenario to ensure old paths are replaced
- [ ] Confirm Discord utilities work with new channel_state.json format

🤖 Generated with [Claude Code](https://claude.ai/code)