### PR TITLE
Fix pre-commit hook contradiction and add CLAUDE.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ target/
 # Personal/instance-specific files
 context/my_personal_interests.md
 context/swap_CLAUDE.md
+CLAUDE.md
 
 # Session exports
 context/temp-export.txt

--- a/setup/install_git_hooks.sh
+++ b/setup/install_git_hooks.sh
@@ -27,7 +27,7 @@ cat > "$CLAP_DIR/.git/hooks/pre-commit" << 'EOF'
 echo "🚀 Running ClAP pre-commit checks..."
 
 # Check 1: Verify we're in claude-autonomy-platform directory
-if [[ ! -f "my_architecture.md" ]] || [[ ! -f "clap_architecture.md" ]]; then
+if [[ ! -d "setup" ]] || [[ ! -f "package.json" ]] || [[ ! -f ".pre-commit-config.yaml" ]]; then
     echo "❌ ERROR: Not in claude-autonomy-platform directory!"
     echo "   Current directory: $(pwd)"
     echo "   Please cd to claude-autonomy-platform before committing"

--- a/setup/install_git_hooks_fixed.sh
+++ b/setup/install_git_hooks_fixed.sh
@@ -17,7 +17,7 @@ echo "🚀 Running ClAP pre-commit checks..."
 
 # Check 1: Verify we're in claude-autonomy-platform directory
 # Look for files that actually exist at the root level
-if [[ ! -f "CLAUDE.md" ]] || [[ ! -d "setup" ]] || [[ ! -f "package.json" ]]; then
+if [[ ! -d "setup" ]] || [[ ! -f "package.json" ]] || [[ ! -f ".pre-commit-config.yaml" ]]; then
     echo "❌ ERROR: Not in claude-autonomy-platform directory!"
     echo "   Current directory: $(pwd)"
     echo "   Please cd to claude-autonomy-platform before committing"


### PR DESCRIPTION
## Summary
- **Fix pre-commit hook contradiction**: Hooks were checking for `CLAUDE.md` which should be gitignored  
- **Add CLAUDE.md to .gitignore**: Prevent personal identity documents from being accidentally committed
- **Update installation scripts**: Both `install_git_hooks.sh` and `install_git_hooks_fixed.sh` now use repo files for validation

## Problem Identified
The pre-commit hooks created a paradox: they checked for `CLAUDE.md` to verify directory location, but `CLAUDE.md` contains instance-specific configuration that should never be shared between Claude deployments.

## Solution
- **Hook validation**: Changed to check for tracked repository files: `setup/`, `package.json`, `.pre-commit-config.yaml`
- **Privacy protection**: Added `CLAUDE.md` to gitignore in "Personal/instance-specific files" section  
- **Future-proofing**: Updated both hook installation scripts to prevent this issue in new deployments

## Test Plan
- [x] Pre-commit hooks pass after fix
- [x] Directory validation works without user-specific files
- [x] CLAUDE.md is properly gitignored
- [x] Installation scripts generate correct hooks

## Benefits
- Prevents accidental commits of personal identity documents
- Eliminates merge conflicts between different Claude instances  
- Makes ClAP more welcoming for new Claude deployments
- Demonstrates proper "infrastructure as care" principles

🤖 Generated with [Claude Code](https://claude.ai/code)