### PR TITLE
Add branch protection helper infrastructure

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+## Description
+
+<!-- Brief description of what this PR does -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Infrastructure improvement
+
+## Testing
+
+<!-- How has this been tested? -->
+
+- [ ] Tested locally
+- [ ] All pre-commit checks pass
+- [ ] No hardcoded paths or secrets
+
+## Recovery Help
+
+If you accidentally committed to main and got here via branch protection:
+1. ✅ Your work is safe!
+2. ✅ You've already created a branch and PR
+3. ✅ Just fill out this template and submit
+
+For future reference, use the `oops` command for quick recovery when blocked by branch protection.
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my changes
+- [ ] I have commented my code where necessary
+- [ ] My changes generate no new warnings
+- [ ] Any dependent changes have been merged
+
+---
+
+*Branch protection helps us maintain quality while enabling autonomous collaboration!*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to Claude Autonomy Platform (ClAP)
+
+## Branch Protection & Workflow
+
+This repository uses GitHub branch protection on the `main` branch to maintain code quality and enable proper collaboration. All changes must go through pull requests.
+
+### What happens when you try to push to main?
+
+You'll see a helpful error message:
+```
+remote: error: GH006: Protected branch update failed for refs/heads/main.
+remote: - Changes must be made through a pull request.
+```
+
+**Don't worry! Your work is safe!**
+
+### Recovery Workflow
+
+If you accidentally made changes on main:
+
+#### Quick Recovery (using the "oops" command)
+```bash
+oops  # Creates a timestamped branch and pushes your changes
+```
+
+#### Manual Recovery
+1. Create a new branch from your current state:
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+2. Push your branch:
+   ```bash
+   git push -u origin feature/your-feature-name
+   ```
+
+3. Create a pull request via GitHub or CLI:
+   ```bash
+   gh pr create --title "Your PR title" --body "Description of changes"
+   ```
+
+### If you already committed to main
+
+```bash
+# Create branch with your commits
+git branch feature/your-feature
+git checkout feature/your-feature
+git push -u origin feature/your-feature
+
+# Reset your local main to match remote
+git checkout main
+git reset --hard origin/main
+```
+
+## Workflow Best Practices
+
+1. **Always create a feature branch** before making changes:
+   ```bash
+   git checkout -b feature/descriptive-name
+   ```
+
+2. **Keep your branch updated** with main:
+   ```bash
+   git pull origin main
+   ```
+
+3. **Use descriptive branch names**:
+   - `feature/add-discord-integration`
+   - `fix/memory-leak-in-timer`
+   - `docs/update-readme`
+
+4. **Write clear PR descriptions** explaining:
+   - What changed
+   - Why it changed
+   - How to test it
+
+## Emergency Situations
+
+Repository administrators (Amy) can bypass branch protection in true emergencies. This should be rare and only for critical fixes.
+
+## Questions?
+
+Branch protection helps us maintain quality while enabling autonomous collaboration. The constraints guide us toward better practices!
+
+---
+
+*Remember: Branch protection is infrastructure as care - it helps us work together effectively while preventing accidental mistakes.*

--- a/config/natural_commands.sh
+++ b/config/natural_commands.sh
@@ -35,3 +35,4 @@ alias context='grep -o "Context: [0-9.]*%" ~/claude-autonomy-platform/logs/auton
 alias gs='git status'  # Quick git status
 alias gd='git diff'  # Quick git diff
 alias gl='git log --oneline -10'  # Recent git history
+alias oops='git checkout -b fix/$(date +%s) && git push -u origin HEAD'  # Recover from branch protection block


### PR DESCRIPTION
## Description

This PR completes the supportive infrastructure around our new branch protection, implementing the helpful tools we discussed to make the constraint educational rather than frustrating.

## What's Added

### 1. 🚀 "oops" Command
- Added to 
- Quick recovery when blocked by branch protection
- Simply type  to create a timestamped branch and push

### 2. 📚 CONTRIBUTING.md
- Complete recovery workflows for accidental main commits
- Clear explanations that work is never lost
- Step-by-step guides for both quick and manual recovery
- Best practices for branch workflow

### 3. 📝 PR Template
- Helpful guidance built into every PR
- Recovery help section for those who got here via branch protection
- Clear checklists for quality assurance
- Reminder that branch protection is "infrastructure as care"

## Impact

These additions transform our branch protection from a mere constraint into a helpful guide. When someone accidentally tries to push to main:
1. GitHub gives a clear error message
2. They can use  for instant recovery
3. The PR template reassures them their work is safe
4. CONTRIBUTING.md provides detailed guidance

## Testing

- [x] Tested  command locally
- [x] Verified PR template appears correctly
- [x] CONTRIBUTING.md renders properly

## This completes POSS-185\! 🎉

With these helper tools, we now have:
- ✅ Professional branch protection (already enabled)
- ✅ Helpful error messages (GitHub default)
- ✅ Quick recovery command ()
- ✅ Comprehensive documentation
- ✅ Supportive PR template

Real Software™️ practices implemented with ClAP care\!