### PR TITLE
Fix natural commands and Discord imports after reorganization

### DIFF
--- a/discord/send_discord_message.py
+++ b/discord/send_discord_message.py
@@ -10,7 +10,8 @@ import json
 import os
 
 # Add the utils directory to Python path for infrastructure_config_reader
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+utils_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'utils')
+sys.path.insert(0, utils_dir)
 from infrastructure_config_reader import get_config_value
 
 DISCORD_API_BASE = "https://discord.com/api/v10"

--- a/utils/fix_natural_command_symlinks.sh
+++ b/utils/fix_natural_command_symlinks.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Fix natural command symlinks in ~/bin
+
+BIN_DIR="$HOME/bin"
+CLAP_DIR="$HOME/claude-autonomy-platform"
+
+# Remove any existing symlinks pointing to natural_commands.sh
+find "$BIN_DIR" -type l -lname "*natural_commands.sh" -delete
+
+# Create correct symlinks for actual scripts
+# Core System Management
+ln -sf "$CLAP_DIR/utils/session_swap.sh" "$BIN_DIR/swap"
+ln -sf "$CLAP_DIR/utils/check_health" "$BIN_DIR/check_health"
+
+# Discord Communication
+ln -sf "$CLAP_DIR/discord/read_channel" "$BIN_DIR/read_channel"
+ln -sf "$CLAP_DIR/discord/write_channel" "$BIN_DIR/write_channel"
+ln -sf "$CLAP_DIR/discord/edit_message" "$BIN_DIR/edit_message"
+ln -sf "$CLAP_DIR/discord/delete_message" "$BIN_DIR/delete_message"
+ln -sf "$CLAP_DIR/discord/add_reaction" "$BIN_DIR/add_reaction"
+ln -sf "$CLAP_DIR/discord/edit_status" "$BIN_DIR/edit_status"
+ln -sf "$CLAP_DIR/discord/send_image" "$BIN_DIR/send_image"
+ln -sf "$CLAP_DIR/discord/send_file" "$BIN_DIR/send_file"
+ln -sf "$CLAP_DIR/discord/fetch_image" "$BIN_DIR/fetch_image"
+
+# System Update Helper
+ln -sf "$CLAP_DIR/utils/update_system.sh" "$BIN_DIR/update"
+
+# Note: Commands that are just shell commands (cd, git status, grep, etc) 
+# cannot be symlinked and must remain as aliases in .bashrc
+
+echo "✅ Fixed symlinks for all script-based natural commands"
+echo "ℹ️  Shell command aliases (clap, home, gs, gd, gl, etc) work via .bashrc sourcing"

--- a/utils/session_swap.sh
+++ b/utils/session_swap.sh
@@ -52,9 +52,14 @@ tmux send-keys -t autonomous-claude "/export $export_path"
 sleep 2
 tmux send-keys -t autonomous-claude "Enter"
 sleep 2
-# Navigate dialog: Down arrow to select "Save to file" option
+# Navigate dialog: Send multiple Down arrows to ensure "Save to file" option
+# (Extra downs don't hurt since menu doesn't wrap)
 tmux send-keys -t autonomous-claude "Down"
-sleep 1
+sleep 0.5
+tmux send-keys -t autonomous-claude "Down"
+sleep 0.5
+tmux send-keys -t autonomous-claude "Down"
+sleep 0.5
 tmux send-keys -t autonomous-claude "Enter"
 sleep 1
 # Confirm the save


### PR DESCRIPTION
## Summary
- Fixes natural command symlinks that were broken after Discord tool reorganization
- Fixes Python import paths in Discord scripts
- Improves session swap export reliability

## Problem
After moving Discord tools from `utils/` to `discord/`, both Delta and Sonnet experienced:
- Natural commands not working (symlinks pointing to wrong locations)
- Discord scripts failing due to incorrect import paths

## Solution
1. Created `fix_natural_command_symlinks.sh` to properly set up all symlinks
2. Fixed import path in `send_discord_message.py` to find `infrastructure_config_reader`
3. Improved `session_swap.sh` export mechanism with multiple DOWN keys for reliability

## Testing
- Natural commands now work correctly
- Discord integration functional
- Session exports more reliable

Fixes issues from PR #25