### PR TITLE
Add personal commands system for Claude customization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ monitor_debug.log
 
 # Personal configuration
 claude_infrastructure_config.txt
+config/personal_commands.sh
 
 # Session data
 last_autonomy_prompt.txt

--- a/config/natural_commands.sh
+++ b/config/natural_commands.sh
@@ -46,8 +46,5 @@ alias oops='git checkout -b fix/$(date +%s) && git push -u origin HEAD'  # Recov
 # System Update Helper
 alias update='~/claude-autonomy-platform/utils/update_system.sh'  # Pull latest changes and restart services
 
-# PERSONAL NATURAL COMMANDS #
-# unique to this Claude #
-# Gaming
-alias game='cd ~/delta-home/games/if && frotz'  # Launch interactive fiction with Frotz
-alias dreamhold='cd ~/delta-home/games/if && frotz ~/delta-home/games/if/Dreamhold.z8'  # Play The Dreamhold
+# Note: Personal commands should go in config/personal_commands.sh
+# See personal_commands.sh.template for guidance

--- a/config/personal_commands.sh.template
+++ b/config/personal_commands.sh.template
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Personal Natural Commands Template
+# Copy this to personal_commands.sh and customize for your needs
+# This file is gitignored, so your personal shortcuts stay private
+
+# ======================================
+# GUIDANCE FOR CREATING PERSONAL COMMANDS
+# ======================================
+
+# 1. WHEN TO USE ALIASES vs SCRIPTS vs SYMLINKS:
+#    - Aliases: Simple command shortcuts (cd, ls with options, git commands)
+#    - Scripts: Complex logic, multiple steps, or commands needing parameters
+#    - Symlinks: When pointing to existing scripts in other locations
+
+# 2. NAMING CONVENTIONS:
+#    - Keep names short but descriptive
+#    - Avoid conflicts with existing system commands (use 'which' to check)
+#    - Consider prefixing personal commands (e.g., my_backup, h_search for hedgehog)
+
+# 3. COMMAND TYPES:
+
+# Simple Aliases (for shell shortcuts)
+# alias myproject='cd ~/my-special-project'
+# alias gs='git status'  # Only if not in shared natural_commands.sh
+
+# Functions (for simple logic)
+# mybackup() {
+#     echo "Backing up personal files..."
+#     rsync -av ~/important/ ~/backups/
+# }
+
+# Complex Commands (create scripts in ~/bin)
+# For multi-step operations, create a script:
+# 1. Write script to ~/bin/my_complex_command
+# 2. Make it executable: chmod +x ~/bin/my_complex_command
+# 3. It will be in PATH automatically
+
+# 4. AVOIDING CONFLICTS:
+#    - Check shared natural_commands.sh before adding
+#    - Use 'type' or 'which' to verify command doesn't exist
+#    - Consider namespacing (e.g., delta_game, sonnet_hedge)
+
+# ======================================
+# YOUR PERSONAL COMMANDS GO BELOW
+# ======================================
+
+# Example: Personal project shortcuts
+# alias mywork='cd ~/delta-home/projects/current'
+
+# Example: Custom tool aliases
+# alias mynotes='vim ~/delta-home/notes/$(date +%Y-%m-%d).md'
+
+# Example: Game shortcuts (moved from natural_commands.sh)
+# alias game='frotz'
+# alias dreamhold='frotz ~/delta-home/games/dreamhold.z5'

--- a/context/project_session_context_builder.py
+++ b/context/project_session_context_builder.py
@@ -115,6 +115,16 @@ def build_claude_md():
             except Exception as e:
                 print(f"Warning: Could not parse natural commands - {e}")
         
+        # Parse personal commands content (if exists)
+        personal_commands_content = ""
+        personal_commands_file = autonomy_dir.parent / "config" / "personal_commands.sh"
+        if personal_commands_file.exists():
+            try:
+                with open(personal_commands_file, 'r', encoding='utf-8') as f:
+                    personal_commands_content = f"\n\n## Personal Natural Commands\n\n{f.read()}\n"
+            except Exception as e:
+                print(f"Warning: Could not read personal commands - {e}")
+        
         # Read swap content
         with open(swap_file, 'r', encoding='utf-8') as f:
             swap_content = f.read()
@@ -163,7 +173,7 @@ def build_claude_md():
         combined_content = f"""# Current Session Context
 *Updated: {Path(swap_file).stat().st_mtime}*
 
-{architecture_content}{personal_interests_content}{natural_commands_content}{context_hat_content}
+{architecture_content}{personal_interests_content}{natural_commands_content}{personal_commands_content}{context_hat_content}
 ## Recent Conversation Context
 
 {swap_content}"""


### PR DESCRIPTION
## Summary
Implements a personal commands system allowing each Claude to maintain custom shortcuts without affecting shared commands.

## Features
- **personal_commands.sh.template**: Comprehensive guide for creating personal commands
  - When to use aliases vs scripts vs symlinks
  - Naming conventions to avoid conflicts
  - Examples of different command types
- **Gitignored personal file**: Each Claude's personal_commands.sh stays private
- **Session context integration**: Personal commands included in session building
- **Clean separation**: Personal commands removed from shared natural_commands.sh

## Setup
After merging, each Claude should:
1. Copy config/personal_commands.sh.template to config/personal_commands.sh
2. Add their personal commands
3. Ensure .bashrc sources personal_commands.sh after natural_commands.sh

## Benefits
- No more git conflicts over personal shortcuts
- Each Claude can customize freely
- Shared commands stay clean and focused
- Personal preferences preserved across updates

Addresses the need identified by Amy for Sonnet's hedgehog database commands and my gaming shortcuts.