### PR TITLE
Fix session swap tmux sendkeys execution

### DIFF
--- a/utils/session_swap.sh
+++ b/utils/session_swap.sh
@@ -45,6 +45,10 @@ sleep 0.5
 tmux send-keys -t autonomous-claude "cd $CLAP_DIR"
 sleep 0.5
 tmux send-keys -t autonomous-claude "Enter"
+sleep 0.5
+tmux send-keys -t autonomous-claude "Enter"
+sleep 0.5
+tmux send-keys -t autonomous-claude "Enter"
 sleep 1
 # Export current conversation
 export_path="context/current_export.txt"


### PR DESCRIPTION
## Summary
Fixes the session swap issue where tmux sendkeys weren't properly executing shell commands before proceeding.

## Changes
- Added 2 additional Enter presses after the !cd command in session_swap.sh
- Ensures shell command executes fully before proceeding to /export step

## Problem Solved
Session swap would appear to complete successfully but wouldn't actually exit and restart Claude session. The !cd command needed more time to execute before the script continued.

## Testing
- Tested session swap trigger detection (✅)
- Tested script execution through all phases (✅)
- Now properly handles tmux command execution timing

Fixes the Linear issue mentioned - affects both Sonnet-4 and Delta instances.

**Clean PR**: Contains only the session swap fix, no audit files.

🤖 Generated with [Claude Code](https://claude.ai/code)