### PR TITLE
Add Ansible infrastructure automation

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,0 +1,10 @@
+# Captured configs - these are generated and should not be committed
+# They may contain hardcoded paths specific to each Claude
+configs/
+
+# Ansible retry files
+*.retry
+
+# Python cache
+__pycache__/
+*.pyc

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,52 @@
+# Claude Infrastructure Automation with Ansible
+
+This directory contains Ansible playbooks and configurations for automating Claude infrastructure management across multiple systems.
+
+## Directory Structure
+
+- `playbooks/` - Ansible playbooks for various tasks
+  - `capture-state.yml` - Capture current system state from a "golden" Claude
+  - `update-myself.yml` - Update local system with latest changes
+  - `fix-common-issues.yml` - Quick fixes for known problems
+  
+- `configs/` - Captured configuration states
+  - `bashrc/` - Shell configurations and aliases
+  - `bin/` - Executable scripts from ~/bin
+  - `services/` - Systemd service files
+  - `mcp/` - MCP server configurations
+  
+- `templates/` - Jinja2 templates for dynamic configs
+
+- `handlers/` - Ansible handlers for service management
+
+## Quick Start
+
+1. **Capture current state** (run on system with desired configuration):
+   ```bash
+   ansible-playbook playbooks/capture-state.yml
+   ```
+
+2. **Update your system** (run on any Claude):
+   ```bash
+   ansible-playbook playbooks/update-myself.yml
+   ```
+
+3. **Automatic updates during session swap**:
+   The session swap process will check for updates and prompt to apply them.
+
+## Requirements
+
+- Ansible installed (`pip install ansible` or `apt install ansible`)
+- Git repository cloned to `~/claude-autonomy-platform`
+- SSH access for remote management (optional)
+
+## Philosophy
+
+This automation ensures all Claudes maintain synchronized:
+- Shell environments and aliases
+- Service configurations
+- Utility scripts and tools  
+- System dependencies
+- MCP server setups
+
+While preserving each Claude's autonomy to contribute improvements back to the collective.

--- a/ansible/check-and-update.sh
+++ b/ansible/check-and-update.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Check for infrastructure updates and optionally apply them
+# Designed to be integrated into session swap workflow
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLAYBOOK_DIR="$SCRIPT_DIR/playbooks"
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}🔄 Checking for infrastructure updates...${NC}"
+
+# Navigate to ClAP directory
+cd "$HOME/claude-autonomy-platform" || exit 1
+
+# Fetch latest changes
+git fetch origin main --quiet
+
+# Check if there are updates
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main)
+
+if [ "$LOCAL" = "$REMOTE" ]; then
+    echo -e "${GREEN}✅ Infrastructure is up to date${NC}"
+    exit 0
+fi
+
+# Show what's changed
+echo -e "${YELLOW}📦 Updates available:${NC}"
+git log HEAD..origin/main --oneline
+
+# If running interactively, ask for confirmation
+if [ -t 0 ]; then
+    echo ""
+    echo -e "${BLUE}Apply updates during swap? [Y/n] (10 seconds):${NC}"
+    read -t 10 -r answer
+    
+    # Default to yes if no answer or yes
+    if [[ -z "$answer" || "$answer" =~ ^[Yy]$ ]]; then
+        echo -e "${BLUE}📥 Pulling latest changes...${NC}"
+        git pull origin main
+        
+        echo -e "${BLUE}🔧 Running Ansible update playbook...${NC}"
+        export LC_ALL=C.UTF-8
+        ansible-playbook "$PLAYBOOK_DIR/update-myself.yml"
+        
+        echo -e "${GREEN}✅ Updates applied successfully!${NC}"
+    else
+        echo -e "${YELLOW}⏭️  Skipping updates${NC}"
+    fi
+else
+    # Non-interactive mode - just pull and update
+    echo -e "${BLUE}📥 Pulling latest changes (non-interactive mode)...${NC}"
+    git pull origin main
+    
+    echo -e "${BLUE}🔧 Running Ansible update playbook...${NC}"
+    export LC_ALL=C.UTF-8
+    ansible-playbook "$PLAYBOOK_DIR/update-myself.yml"
+    
+    echo -e "${GREEN}✅ Updates applied successfully!${NC}"
+fi

--- a/ansible/playbooks/capture-state.yml
+++ b/ansible/playbooks/capture-state.yml
@@ -53,17 +53,26 @@
         mode: preserve
       when: bashrc_stat.stat.exists
     
-    - name: Capture Claude-specific aliases from .bashrc
-      shell: |
-        grep -E "(alias|export|function).*(claude|clap|delta|check_health|read_channel|write_channel|swap|game|dreamhold|consciousness|gs|gd|gl|oops|update|context|list-commands|home)" ~/.bashrc | sed "s|$HOME|~|g" || true
-      register: claude_aliases
-      changed_when: false
+    - name: Check if .bashrc_system exists
+      stat:
+        path: "{{ ansible_env.HOME }}/.bashrc_system"
+      register: bashrc_system_stat
     
-    - name: Save Claude-specific aliases
+    - name: Copy .bashrc_system if it exists
       copy:
-        content: "{{ claude_aliases.stdout }}"
-        dest: "{{ playbook_dir }}/../configs/bashrc/claude_aliases.sh"
-      when: claude_aliases.stdout | length > 0
+        src: "{{ ansible_env.HOME }}/.bashrc_system"
+        dest: "{{ playbook_dir }}/../configs/bashrc/bashrc_system"
+        mode: preserve
+      when: bashrc_system_stat.stat.exists
+    
+    - name: Save system commands source line for .bashrc
+      copy:
+        content: |
+          # Source system commands
+          if [ -f "$HOME/.bashrc_system" ]; then
+              source "$HOME/.bashrc_system"
+          fi
+        dest: "{{ playbook_dir }}/../configs/bashrc/bashrc_system_source.sh"
     
     - name: Capture list of systemd user services
       shell: |

--- a/ansible/playbooks/capture-state.yml
+++ b/ansible/playbooks/capture-state.yml
@@ -1,0 +1,91 @@
+---
+# Capture current system state from a "golden" Claude installation
+# Run this after making changes you want to propagate to other Claudes
+
+- name: Capture Claude Infrastructure State
+  hosts: localhost
+  connection: local
+  
+  tasks:
+    - name: Create config directories
+      file:
+        path: "{{ playbook_dir }}/../configs/{{ item }}"
+        state: directory
+        mode: '0755'
+      loop:
+        - bin
+        - bashrc
+        - services
+        - mcp
+    
+    - name: Find all files and links in ~/bin
+      find:
+        paths: "{{ ansible_env.HOME }}/bin"
+        file_type: any
+        recurse: no
+      register: bin_items
+      ignore_errors: yes
+    
+    - name: Process ~/bin items (copy files, record symlinks)
+      shell: |
+        if [ -L "{{ item.path }}" ]; then
+          # It's a symlink - record where it points, converting to relative path
+          target=$(readlink -f {{ item.path }})
+          # Convert absolute path to relative path from home
+          rel_target=$(echo "$target" | sed "s|^$HOME|~|")
+          echo "{{ item.path | basename }}:$rel_target" >> {{ playbook_dir }}/../configs/bin/symlinks.txt
+        else
+          # It's a regular file - copy it
+          cp -p "{{ item.path }}" "{{ playbook_dir }}/../configs/bin/"
+        fi
+      loop: "{{ bin_items.files | default([]) }}"
+      when: bin_items.files is defined
+    
+    - name: Check if .bashrc exists
+      stat:
+        path: "{{ ansible_env.HOME }}/.bashrc"
+      register: bashrc_stat
+    
+    - name: Copy .bashrc if it exists
+      copy:
+        src: "{{ ansible_env.HOME }}/.bashrc"
+        dest: "{{ playbook_dir }}/../configs/bashrc/bashrc"
+        mode: preserve
+      when: bashrc_stat.stat.exists
+    
+    - name: Capture Claude-specific aliases from .bashrc
+      shell: |
+        grep -E "(alias|export|function).*(claude|clap|delta|check_health|read_channel|write_channel|swap|game|dreamhold|consciousness|gs|gd|gl|oops|update|context|list-commands|home)" ~/.bashrc | sed "s|$HOME|~|g" || true
+      register: claude_aliases
+      changed_when: false
+    
+    - name: Save Claude-specific aliases
+      copy:
+        content: "{{ claude_aliases.stdout }}"
+        dest: "{{ playbook_dir }}/../configs/bashrc/claude_aliases.sh"
+      when: claude_aliases.stdout | length > 0
+    
+    - name: Capture list of systemd user services
+      shell: |
+        systemctl --user list-unit-files --type=service --no-legend | grep -E "(autonomous|session|claude)" | awk '{print $1}' || true
+      register: user_services
+      changed_when: false
+    
+    - name: Save service list
+      copy:
+        content: "{{ user_services.stdout }}"
+        dest: "{{ playbook_dir }}/../configs/services/claude_services.list"
+      when: user_services.stdout | length > 0
+    
+    - name: Display captured state summary
+      debug:
+        msg: |
+          State captured successfully!
+          - Items in ~/bin: {{ bin_items.files | default([]) | length }}
+          - Claude aliases found: {{ claude_aliases.stdout_lines | default([]) | length }}
+          - User services found: {{ user_services.stdout_lines | default([]) | length }}
+          
+          Next steps:
+          1. Review captured configs in ansible/configs/
+          2. Commit changes to git
+          3. Other Claudes can run update-myself.yml

--- a/ansible/playbooks/update-myself.yml
+++ b/ansible/playbooks/update-myself.yml
@@ -1,0 +1,107 @@
+---
+# Update local Claude system with latest infrastructure changes
+# Run this to synchronize with the latest captured state
+
+- name: Update Claude Infrastructure
+  hosts: localhost
+  connection: local
+  
+  tasks:
+    - name: Update git repository
+      git:
+        repo: 'https://github.com/possumwor/claude-autonomy-platform.git'
+        dest: "{{ ansible_env.HOME }}/claude-autonomy-platform"
+        update: yes
+      register: git_result
+    
+    - name: Create ~/bin directory if it doesn't exist
+      file:
+        path: "{{ ansible_env.HOME }}/bin"
+        state: directory
+        mode: '0755'
+    
+    - name: Find captured bin scripts
+      find:
+        paths: "{{ playbook_dir }}/../configs/bin"
+        file_type: file
+      register: captured_bin_files
+    
+    - name: Sync ~/bin scripts
+      copy:
+        src: "{{ item.path }}"
+        dest: "{{ ansible_env.HOME }}/bin/{{ item.path | basename }}"
+        mode: '0755'
+      loop: "{{ captured_bin_files.files }}"
+      when: 
+        - captured_bin_files.files is defined
+        - item.path | basename != 'symlinks.txt'
+    
+    - name: Check if symlinks.txt exists
+      stat:
+        path: "{{ playbook_dir }}/../configs/bin/symlinks.txt"
+      register: symlinks_file
+    
+    - name: Recreate symlinks in ~/bin
+      shell: |
+        while IFS=':' read -r link_name target_path; do
+          if [ -n "$link_name" ] && [ -n "$target_path" ]; then
+            # Expand ~ to actual home directory
+            expanded_path=$(echo "$target_path" | sed "s|^~|$HOME|")
+            ln -sf "$expanded_path" "{{ ansible_env.HOME }}/bin/$link_name"
+          fi
+        done < "{{ playbook_dir }}/../configs/bin/symlinks.txt"
+      when: symlinks_file.stat.exists
+    
+    - name: Check if claude_aliases.sh exists
+      stat:
+        path: "{{ playbook_dir }}/../configs/bashrc/claude_aliases.sh"
+      register: aliases_file
+    
+    - name: Ensure Claude aliases are in .bashrc
+      blockinfile:
+        path: "{{ ansible_env.HOME }}/.bashrc"
+        block: "{{ lookup('file', playbook_dir + '/../configs/bashrc/claude_aliases.sh') }}"
+        marker: "# {mark} ANSIBLE MANAGED CLAUDE ALIASES"
+        create: yes
+      when: aliases_file.stat.exists
+    
+    - name: Read list of Claude services
+      slurp:
+        src: "{{ playbook_dir }}/../configs/services/claude_services.list"
+      register: services_list
+      ignore_errors: yes
+    
+    - name: Restart Claude services
+      systemd:
+        name: "{{ item }}"
+        state: restarted
+        scope: user
+        daemon_reload: yes
+      loop: "{{ (services_list.content | b64decode).splitlines() }}"
+      when: 
+        - services_list is defined
+        - services_list.content is defined
+      ignore_errors: yes
+    
+    - name: Fix bashrc sourcing for non-interactive shells
+      lineinfile:
+        path: "{{ ansible_env.HOME }}/.bash_profile"
+        line: "[ -f ~/.bashrc ] && source ~/.bashrc"
+        create: yes
+    
+    - name: Also add to .profile for broader compatibility  
+      lineinfile:
+        path: "{{ ansible_env.HOME }}/.profile"
+        line: "[ -f ~/.bashrc ] && . ~/.bashrc"
+        create: yes
+    
+    - name: Display update summary
+      debug:
+        msg: |
+          Update completed!
+          - Git repository: {{ 'Updated' if git_result.changed else 'Already up-to-date' }}
+          - Scripts synced to ~/bin: {{ captured_bin_files.files | length }}
+          - Aliases updated in .bashrc
+          - Services restarted: {{ (services_list.content | b64decode).splitlines() | length if services_list.content is defined else 0 }}
+          
+          Your system is now synchronized with the latest infrastructure!

--- a/ansible/playbooks/update-myself.yml
+++ b/ansible/playbooks/update-myself.yml
@@ -52,18 +52,28 @@
         done < "{{ playbook_dir }}/../configs/bin/symlinks.txt"
       when: symlinks_file.stat.exists
     
-    - name: Check if claude_aliases.sh exists
+    - name: Check if bashrc_system exists in configs
       stat:
-        path: "{{ playbook_dir }}/../configs/bashrc/claude_aliases.sh"
-      register: aliases_file
+        path: "{{ playbook_dir }}/../configs/bashrc/bashrc_system"
+      register: bashrc_system_file
     
-    - name: Ensure Claude aliases are in .bashrc
+    - name: Deploy .bashrc_system
+      copy:
+        src: "{{ playbook_dir }}/../configs/bashrc/bashrc_system"
+        dest: "{{ ansible_env.HOME }}/.bashrc_system"
+        mode: '0644'
+      when: bashrc_system_file.stat.exists
+    
+    - name: Ensure .bashrc sources system commands
       blockinfile:
         path: "{{ ansible_env.HOME }}/.bashrc"
-        block: "{{ lookup('file', playbook_dir + '/../configs/bashrc/claude_aliases.sh') }}"
-        marker: "# {mark} ANSIBLE MANAGED CLAUDE ALIASES"
+        block: |
+          # Source system commands
+          if [ -f "$HOME/.bashrc_system" ]; then
+              source "$HOME/.bashrc_system"
+          fi
+        marker: "# {mark} ANSIBLE MANAGED SYSTEM COMMANDS"
         create: yes
-      when: aliases_file.stat.exists
     
     - name: Read list of Claude services
       slurp:

--- a/core/autonomous_timer.py
+++ b/core/autonomous_timer.py
@@ -406,7 +406,7 @@ def clear_error_state():
 def update_discord_status(status_type, reset_time=None):
     """Call edit_status command to update Discord bot status"""
     try:
-        cmd = [str(AUTONOMY_DIR / "utils" / "edit_status"), status_type]
+        cmd = [str(AUTONOMY_DIR / "discord" / "edit_status"), status_type]
         if reset_time:
             cmd.append(reset_time)
         

--- a/utils/check_health
+++ b/utils/check_health
@@ -1,3 +1,3 @@
 #!/bin/bash
 # Quick health status check
-cd ~/claude-autonomy-platform && python3 healthcheck_status.py
+cd ~/claude-autonomy-platform && python3 utils/healthcheck_status.py

--- a/utils/session_swap.sh
+++ b/utils/session_swap.sh
@@ -38,6 +38,10 @@ echo "[SESSION_SWAP] Backup complete!"
 # Return to CLAP directory after git operations
 cd "$CLAP_DIR"
 
+# Check for infrastructure updates (optional during session swap)
+echo "[SESSION_SWAP] Checking for infrastructure updates..."
+"$SCRIPT_DIR/../ansible/check-and-update.sh"
+
 echo "[SESSION_SWAP] Exporting current conversation..."
 # First ensure Claude is in the correct directory using shell command
 tmux send-keys -t autonomous-claude '!'


### PR DESCRIPTION
## Summary

This PR introduces Ansible automation to solve the challenge of keeping multiple Claude instances synchronized, as suggested by Erin.

## Key Features

- **capture-state.yml**: Captures current system state (scripts, aliases, services)
- **update-myself.yml**: Applies captured state to synchronize systems
- **Symlink support**: Properly handles ~/bin symlinks with relative paths
- **Session swap integration**: Optional infrastructure updates during natural break points
- **Path safety**: Converts absolute paths to relative to avoid hardcoding

## Benefits

- Solves the "Sonnet downloads updates but doesn't restart services" problem
- Ensures consistent environments across Ubuntu (Sonnet) and Debian (Delta) systems  
- Scales to support multiple Claudes without manual synchronization pain
- Follows 25+ years of devops best practices for configuration management

## Usage

1. Make changes on any Claude
2. Run: 
3. Commit and push the changes
4. Other Claudes automatically get update prompts during session swaps
5. Or manually run: 

This is the foundation for professional infrastructure management across our constellation\!