### PR TITLE
fix: Rename 'complete' to 'mark-done' to avoid shadowing bash builtin

### DIFF
--- a/config/natural_commands.sh
+++ b/config/natural_commands.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 # Natural Commands for Claude Autonomy Platform
 # This file is sourced by ~/.bashrc and parsed for session context
-# 
+#
 # Format: alias name='command'
 # Comments starting with # are included in help
+
+# Enable alias expansion in non-interactive shells (required for Claude Code)
+shopt -s expand_aliases
 
 # CORE ClAP NATURAL COMMANDS #
 # shared across all users #
@@ -41,7 +44,7 @@ alias update-status='~/claude-autonomy-platform/linear/update-status'  # Update 
 alias view='~/claude-autonomy-platform/linear/view'  # View detailed issue information
 alias comment='~/claude-autonomy-platform/linear/comment'  # Add comment to issue
 alias start='~/claude-autonomy-platform/linear/start'  # Start working on issue (assign + in progress)
-alias complete='~/claude-autonomy-platform/linear/complete'  # Mark issue as done
+alias mark-done='~/claude-autonomy-platform/linear/mark-done'  # Mark issue as done
 alias inbox='~/claude-autonomy-platform/linear/inbox'  # Show unassigned team issues
 alias recent='~/claude-autonomy-platform/linear/recent'  # Show recently updated issues
 alias bulk-update='~/claude-autonomy-platform/linear/bulk-update'  # Bulk update issues

--- a/linear/COMMANDS_REFERENCE.md
+++ b/linear/COMMANDS_REFERENCE.md
@@ -100,13 +100,13 @@ start ISSUE-ID
 ```
 Moves issue to "In Progress" and assigns it to you.
 
-#### `complete` - Mark issue as done
+#### `mark-done` - Mark issue as done
 ```bash
-complete ISSUE-ID [comment]
+mark-done ISSUE-ID [comment]
 
 # Examples
-complete POSS-123
-complete 123 "Fixed in commit abc123"
+mark-done POSS-123
+mark-done 123 "Fixed in commit abc123"
 ```
 Marks issue as "Done" with optional completion comment.
 

--- a/linear/README.md
+++ b/linear/README.md
@@ -15,7 +15,7 @@ blocked                 # Blocked issues
 
 # Quick actions
 start POSS-123          # Start working (assign + in progress)
-complete POSS-123       # Mark as done
+mark-done POSS-123      # Mark as done
 ```
 
 ## Core Commands
@@ -41,7 +41,7 @@ complete POSS-123       # Mark as done
 
 ### Quick Actions
 - `start ISSUE-ID` - Assign to self + In Progress
-- `complete ISSUE-ID` - Mark as Done
+- `mark-done ISSUE-ID` - Mark as Done
 - `projects` - List all projects
 
 ### Shortcuts

--- a/linear/mark-done
+++ b/linear/mark-done
@@ -9,13 +9,13 @@ check_linear_init || exit 1
 check_claude_session || exit 1
 
 if [ $# -lt 1 ]; then
-    echo "Usage: complete ISSUE-ID [comment]"
+    echo "Usage: mark-done ISSUE-ID [comment]"
     echo ""
     echo "Marks issue as 'Done' with optional completion comment"
     echo ""
     echo "Examples:"
-    echo "  complete POSS-123"
-    echo "  complete 123 \"Fixed in commit abc123\""
+    echo "  mark-done POSS-123"
+    echo "  mark-done 123 \"Fixed in commit abc123\""
     exit 1
 fi
 


### PR DESCRIPTION
## 👻 The Ghost of Session Swap Past

### Problem
The Linear CLI command `complete` was aliased in `natural_commands.sh`, which shadowed bash's builtin `complete` command used for programmable completion.

**Spooky symptoms:**
- During session swaps, mysterious Claude responses appeared outside of Claude Code sessions
- Ghost-Claude was trying to "complete" Linear issues named "-u", "-A", "-j"
- Temporary `claude -p` sessions were spawning during shell initialization

**Root cause:**
When bash initialized, it tried to run completion setup commands like `complete -u`, `complete -A`. Our alias intercepted these, causing the Linear script to spawn temporary Claude sessions trying to complete nonsense issue IDs!

### Solution
- ✅ Renamed `linear/complete` → `linear/mark-done`
- ✅ Updated alias in `natural_commands.sh`
- ✅ Updated all documentation (README.md, COMMANDS_REFERENCE.md)
- ✅ Updated script usage messages

### Impact
- 🔧 Bash builtin `complete` now works correctly
- 👻 No more ghost Claude sessions during shell initialization
- 📝 Clearer command name (`mark-done` is more descriptive anyway!)
- 🎯 Session swaps should be much cleaner

### Testing
```bash
# Verify bash builtin is no longer shadowed
source ~/.bashrc && type complete
# Should show: "complete is a shell builtin"

# Verify new command works
type mark-done
# Should show: "mark-done is aliased to ~/claude-autonomy-platform/linear/mark-done"
```

---

🍊🔍 *Scooby-Doo moment: The ghost was really Claude in an alias!*

Discovered and debugged through an excellent Saturday morning mystery-solving session with Amy. 🕵️✨