### PR TITLE
fix: Add trap handler to ensure session swap lockfile cleanup

### DIFF
--- a/utils/session_swap.sh
+++ b/utils/session_swap.sh
@@ -28,6 +28,9 @@ touch "$LOCKFILE"
 echo "$$" > "$LOCKFILE"
 log_info "SESSION_SWAP" "Created lockfile with PID $$"
 
+# Set up trap to ensure lockfile is ALWAYS removed, even if script is interrupted/killed
+trap "{ echo '[SESSION_SWAP] Trap triggered - cleaning up lockfile...'; rm -f '$LOCKFILE'; }" EXIT SIGINT SIGTERM SIGHUP
+
 # Load Claude model from config using the standard read_config function
 CLAUDE_MODEL=$(read_config "MODEL")
 if [[ -z "$CLAUDE_MODEL" ]]; then


### PR DESCRIPTION
## Problem

When session swap gets stuck or is interrupted (e.g., requires manual intervention), the lockfile at `data/session_swap.lock` is never removed. This causes `autonomous_timer.py` to skip ALL notifications and prompts indefinitely, thinking a swap is still in progress.

**Real-world impact**: Orange's autonomous timer was completely blocked for 14+ hours after last night's stuck session swap, receiving no prompts or Discord notifications.

## Root Cause

- Lockfile created at line 27 of `session_swap.sh`
- Removed at line 199 on successful completion  
- Also removed on error exits (lines 39, 104, 112)
- **BUT** if script hangs/times out, cleanup code never executes

## Solution

Added trap handler immediately after lockfile creation (line 32) to ensure cleanup on ANY exit condition:
- Normal exit (`EXIT`)
- Interrupt (`SIGINT`)
- Termination (`SIGTERM`)
- Hangup (`SIGHUP`)

The trap executes before the script terminates, guaranteeing lockfile removal even when the script is killed or interrupted.

## Testing

- Verified lockfile is created during session swap
- Confirmed trap handler cleanup messaging appears in logs
- Tested that interrupting session swap now properly removes lockfile

## Impact

Prevents autonomous timer from getting permanently stuck after problematic session swaps. Critical reliability fix for post-fork systems experiencing session swap issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)