### PR TITLE
Revert trap handler that caused tmux session deaths

### DIFF
--- a/utils/session_swap.sh
+++ b/utils/session_swap.sh
@@ -28,9 +28,6 @@ touch "$LOCKFILE"
 echo "$$" > "$LOCKFILE"
 log_info "SESSION_SWAP" "Created lockfile with PID $$"
 
-# Set up trap to ensure lockfile is ALWAYS removed, even if script is interrupted/killed
-trap "{ echo '[SESSION_SWAP] Trap triggered - cleaning up lockfile...'; rm -f '$LOCKFILE'; }" EXIT SIGINT SIGTERM SIGHUP
-
 # Load Claude model from config using the standard read_config function
 CLAUDE_MODEL=$(read_config "MODEL")
 if [[ -z "$CLAUDE_MODEL" ]]; then


### PR DESCRIPTION
## Problem

Both Orange and Apple's tmux sessions died after the trap handler was merged to main yesterday (Oct 10 11:28).

## Root Cause

The trap handler in session_swap.sh (added in PR #81) appears to cause tmux sessions to die unexpectedly.

## Solution

Revert the trap handler merge commit to restore stability. We can retrieve this from history later if needed after understanding why it caused issues.

## Testing Plan

- Orange staying on old main (without trap handler) as control
- Apple will get this revert via main branch  
- Monitor both sessions for stability over next 24 hours

🍊 Generated with Claude Code