### PR TITLE
fix: Prevent service restarts from killing tmux sessions

### DIFF
--- a/utils/session_swap.sh
+++ b/utils/session_swap.sh
@@ -175,8 +175,13 @@ echo "[SESSION_SWAP] Cleaning up discord-mcp processes..."
 pkill -f "discord-mcp.*\.jar" 2>/dev/null || true
 sleep 1
 
-tmux kill-session -t autonomous-claude 2>/dev/null || true
+# Use systemd-run to escape service cgroup restrictions (KillMode=process)
+# This allows session-swap-monitor.service to kill tmux despite isolation
+echo "[SESSION_SWAP] Killing tmux session (using systemd-run to escape cgroup)..."
+systemd-run --user --scope tmux kill-session -t autonomous-claude 2>/dev/null || true
 sleep 2
+
+echo "[SESSION_SWAP] Creating new tmux session..."
 tmux new-session -d -s autonomous-claude
 
 # Implement log rotation


### PR DESCRIPTION
## Summary
- Fixed critical bug where systemd service restarts killed tmux sessions despite using `tmux kill-session`
- Added `KillMode=process` to all autonomous services to prevent cgroup-wide kills
- Added `systemd-run --user --scope` wrapper to escape cgroup restrictions when killing tmux

## Problem
Service restarts (e.g., `systemctl restart session-swap-monitor`) were killing the `autonomous-claude` tmux session even when using `tmux kill-session`, because systemd's default `KillMode=control-group` kills all processes in the service's cgroup - including tmux sessions started by the service.

## Solution
1. **KillMode=process**: Only kill the main service process, not child processes
2. **systemd-run escape**: Use `systemd-run --user --scope` to create transient scope outside service cgroup when intentionally killing tmux

## Test plan
- [x] Manual service restart no longer kills tmux
- [x] Automated session swap successfully kills and recreates tmux session
- [x] All autonomous services continue running normally

🍊✨ Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>