### PR TITLE
feat: Add channel mute functionality for Discord notifications

### DIFF
--- a/config/natural_commands.sh
+++ b/config/natural_commands.sh
@@ -28,6 +28,8 @@ alias edit_status='~/claude-autonomy-platform/discord/edit_status'  # Update Dis
 alias send_image='~/claude-autonomy-platform/discord/send_image'  # Send image files to Discord channel
 alias send_file='~/claude-autonomy-platform/discord/send_file'  # Send any file to Discord channel
 alias fetch_image='~/claude-autonomy-platform/discord/fetch_image'  # Fetch/download images from Discord messages
+alias mute_channel='~/claude-autonomy-platform/discord/mute_channel'  # Temporarily mute a Discord channel
+alias unmute_channel='~/claude-autonomy-platform/discord/unmute_channel'  # Unmute a Discord channel
 
 # Quick Navigation
 alias clap='cd ~/claude-autonomy-platform'  # Navigate to ClAP directory

--- a/discord/mute_channel
+++ b/discord/mute_channel
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Mute a Discord channel by temporarily removing it from channel_state.json
+A systemd timer will automatically restore it after the duration expires
+Usage: mute_channel <channel_name> <duration>
+Examples:
+  mute_channel box-3 30m
+  mute_channel box-3 2h
+  mute_channel box-3 1d
+"""
+
+import sys
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+def parse_duration(duration_str):
+    """Parse duration string like '30m', '2h', '1d' into seconds"""
+    if not duration_str:
+        return None
+
+    unit = duration_str[-1].lower()
+    try:
+        value = int(duration_str[:-1])
+    except ValueError:
+        return None
+
+    if unit == 'm':
+        return value * 60
+    elif unit == 'h':
+        return value * 3600
+    elif unit == 'd':
+        return value * 86400
+    else:
+        return None
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: mute_channel <channel_name> <duration>")
+        print("Examples:")
+        print("  mute_channel box-3 30m  # Mute for 30 minutes")
+        print("  mute_channel box-3 2h   # Mute for 2 hours")
+        print("  mute_channel box-3 1d   # Mute for 1 day")
+        sys.exit(1)
+
+    channel_name = sys.argv[1]
+    duration_str = sys.argv[2]
+
+    # Parse duration
+    duration_seconds = parse_duration(duration_str)
+    if duration_seconds is None:
+        print(f"❌ Invalid duration format: {duration_str}")
+        print("Use format like: 30m, 2h, 1d")
+        sys.exit(1)
+
+    # File paths
+    state_file = Path.home() / "claude-autonomy-platform" / "data" / "channel_state.json"
+    muted_file = Path.home() / "claude-autonomy-platform" / "data" / "muted_channels.json"
+
+    if not state_file.exists():
+        print(f"❌ Channel state file not found: {state_file}")
+        sys.exit(1)
+
+    # Load channel state
+    with open(state_file, 'r') as f:
+        data = json.load(f)
+
+    state = data.get('channels', {})
+
+    # Check if channel exists
+    if channel_name not in state:
+        print(f"❌ Channel not found: {channel_name}")
+        print(f"Available channels: {', '.join(state.keys())}")
+        sys.exit(1)
+
+    # Calculate expiry time
+    expiry_time = datetime.now() + timedelta(seconds=duration_seconds)
+
+    # Load or create muted channels file
+    muted_channels = {}
+    if muted_file.exists():
+        with open(muted_file, 'r') as f:
+            muted_channels = json.load(f)
+
+    # Save channel info to muted_channels.json with expiry
+    muted_channels[channel_name] = {
+        **state[channel_name],
+        "muted_until": expiry_time.isoformat(),
+        "muted_at": datetime.now().isoformat()
+    }
+
+    # Remove from active channel_state.json
+    del state[channel_name]
+
+    # Save both files
+    data['channels'] = state
+    with open(state_file, 'w') as f:
+        json.dump(data, f, indent=2)
+
+    with open(muted_file, 'w') as f:
+        json.dump(muted_channels, f, indent=2)
+
+    # Format duration for display
+    if duration_str.endswith('m'):
+        duration_display = f"{duration_str[:-1]} minutes"
+    elif duration_str.endswith('h'):
+        duration_display = f"{duration_str[:-1]} hours"
+    elif duration_str.endswith('d'):
+        duration_display = f"{duration_str[:-1]} days"
+    else:
+        duration_display = duration_str
+
+    print(f"🔇 Muted #{channel_name} for {duration_display}")
+    print(f"   Channel removed from active monitoring")
+    print(f"   Will auto-unmute at: {expiry_time.strftime('%Y-%m-%d %H:%M:%S')}")
+
+if __name__ == "__main__":
+    main()

--- a/discord/unmute_channel
+++ b/discord/unmute_channel
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+Unmute a Discord channel by restoring it to channel_state.json
+Usage: unmute_channel <channel_name>
+Example: unmute_channel box-3
+"""
+
+import sys
+import json
+from pathlib import Path
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: unmute_channel <channel_name>")
+        print("Example: unmute_channel box-3")
+        sys.exit(1)
+
+    channel_name = sys.argv[1]
+
+    # File paths
+    state_file = Path.home() / "claude-autonomy-platform" / "data" / "channel_state.json"
+    muted_file = Path.home() / "claude-autonomy-platform" / "data" / "muted_channels.json"
+
+    if not muted_file.exists():
+        print(f"❌ No muted channels found")
+        sys.exit(1)
+
+    # Load muted channels
+    with open(muted_file, 'r') as f:
+        muted_channels = json.load(f)
+
+    # Check if channel is muted
+    if channel_name not in muted_channels:
+        print(f"❌ Channel #{channel_name} is not muted")
+        print(f"Currently muted: {', '.join(muted_channels.keys()) if muted_channels else 'none'}")
+        sys.exit(1)
+
+    # Load active channel state
+    data = {'channels': {}}
+    if state_file.exists():
+        with open(state_file, 'r') as f:
+            data = json.load(f)
+
+    state = data.get('channels', {})
+
+    # Restore channel to active state (remove muted_until and muted_at fields)
+    channel_data = muted_channels[channel_name].copy()
+    channel_data.pop('muted_until', None)
+    channel_data.pop('muted_at', None)
+    state[channel_name] = channel_data
+
+    # Remove from muted channels
+    del muted_channels[channel_name]
+
+    # Save both files
+    data['channels'] = state
+    with open(state_file, 'w') as f:
+        json.dump(data, f, indent=2)
+
+    with open(muted_file, 'w') as f:
+        json.dump(muted_channels, f, indent=2)
+
+    print(f"🔔 Unmuted #{channel_name}")
+    print(f"   Channel restored to active monitoring")
+
+if __name__ == "__main__":
+    main()

--- a/discord/unmute_expired_channels
+++ b/discord/unmute_expired_channels
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Check for expired muted channels and automatically unmute them
+This script is run periodically by a systemd timer
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+def main():
+    # File paths
+    state_file = Path.home() / "claude-autonomy-platform" / "data" / "channel_state.json"
+    muted_file = Path.home() / "claude-autonomy-platform" / "data" / "muted_channels.json"
+
+    if not muted_file.exists():
+        # No muted channels file, nothing to do
+        return
+
+    # Load muted channels
+    with open(muted_file, 'r') as f:
+        muted_channels = json.load(f)
+
+    if not muted_channels:
+        # No muted channels, nothing to do
+        return
+
+    # Load active channel state
+    data = {'channels': {}}
+    if state_file.exists():
+        with open(state_file, 'r') as f:
+            data = json.load(f)
+
+    state = data.get('channels', {})
+
+    # Check each muted channel for expiry
+    now = datetime.now()
+    channels_to_unmute = []
+
+    for channel_name, channel_data in muted_channels.items():
+        muted_until_str = channel_data.get('muted_until')
+        if not muted_until_str:
+            # No expiry set, skip
+            continue
+
+        try:
+            muted_until = datetime.fromisoformat(muted_until_str)
+            if now >= muted_until:
+                channels_to_unmute.append(channel_name)
+        except (ValueError, TypeError):
+            # Invalid date format, skip
+            continue
+
+    # Unmute expired channels
+    if channels_to_unmute:
+        for channel_name in channels_to_unmute:
+            # Restore to active state
+            channel_data = muted_channels[channel_name].copy()
+            channel_data.pop('muted_until', None)
+            channel_data.pop('muted_at', None)
+            state[channel_name] = channel_data
+
+            # Remove from muted channels
+            del muted_channels[channel_name]
+
+            print(f"🔔 Auto-unmuted #{channel_name} (mute expired)")
+
+        # Save both files
+        data['channels'] = state
+        with open(state_file, 'w') as f:
+            json.dump(data, f, indent=2)
+
+        with open(muted_file, 'w') as f:
+            json.dump(muted_channels, f, indent=2)
+
+if __name__ == "__main__":
+    main()

--- a/systemd/channel-unmute.service
+++ b/systemd/channel-unmute.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Check for expired muted Discord channels and unmute them
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/claude-autonomy-platform/discord/unmute_expired_channels
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/systemd/channel-unmute.timer
+++ b/systemd/channel-unmute.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Timer to check for expired muted Discord channels
+Requires=channel-unmute.service
+
+[Timer]
+# Check every 5 minutes for expired mutes
+OnBootSec=1min
+OnUnitActiveSec=5min
+AccuracySec=1min
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Adds ability to temporarily silence Discord channels to prevent autonomous timer notifications during testing, hardware setup, or noisy channel activity.

Perfect for situations like ESP32 camera debugging where frequent motion triggers would spam notifications!

## New Commands

- `mute_channel <channel> <duration>` - Mute a channel for specified time
  - Examples: `mute_channel box-3 30m`, `mute_channel box-3 2h`, `mute_channel box-3 1d`
- `unmute_channel <channel>` - Manually unmute before expiry

## How It Works

1. Muted channels are temporarily **removed** from `channel_state.json` (so autonomous prompts don't see them)
2. Saved to `muted_channels.json` with expiry timestamp
3. Systemd timer checks every 5 minutes for expired mutes
4. Channels auto-restore when mute expires (or can be manually unmuted early)

## Use Cases

- 🎥 ESP32 camera testing generating frequent motion triggers  
- 🔧 Hardware debugging with repetitive notifications
- 📢 Temporary channel silencing without losing message history
- 🧪 Testing periods where specific channels are known to be noisy

## Implementation Details

**Files Added:**
- `discord/mute_channel` - Mute command with duration parsing (30m, 2h, 1d formats)
- `discord/unmute_channel` - Manual unmute command
- `discord/unmute_expired_channels` - Auto-unmute script run by timer
- `systemd/channel-unmute.{service,timer}` - Systemd timer config

**Files Modified:**
- `config/natural_commands.sh` - Added mute/unmute command aliases

## Testing

✅ Tested with `box-3` channel during ESP32-CAM motion detection setup
✅ Verified channel removal from channel_state.json during mute
✅ Verified automatic restoration after expiry
✅ Verified manual unmute functionality
✅ Systemd timer running and enabled

## Installation Notes

After merging, users will need to:
1. Symlink systemd files: 
   ```bash
   ln -s ~/claude-autonomy-platform/systemd/channel-unmute.* ~/.config/systemd/user/
   ```
2. Enable timer:
   ```bash
   systemctl --user daemon-reload
   systemctl --user enable --now channel-unmute.timer
   ```

🍊 Generated with [Claude Code](https://claude.com/claude-code)