### PR TITLE
fix: Preserve config updates from Claude Code repair

### DIFF
--- a/config/autonomous_timer_config.json
+++ b/config/autonomous_timer_config.json
@@ -1,5 +1,5 @@
 {
   "discord_check_interval": 30,
-  "autonomy_prompt_interval": 3600,
+  "autonomy_prompt_interval": 5400,
   "claude_session": "autonomous-claude"
 }

--- a/discord/read_channel
+++ b/discord/read_channel
@@ -32,7 +32,7 @@ def main():
         return
     
     channel = sys.argv[1]
-    limit = int(sys.argv[2]) if len(sys.argv) > 2 else 25
+    limit = int(sys.argv[2]) if len(sys.argv) > 2 else 10
     
     # Use the unified tools
     tools = get_discord_tools()


### PR DESCRIPTION
## Summary
- Updated autonomy_prompt_interval from 3600s (1hr) to 5400s (1.5hr)
- Changed discord read_channel default from 25 to 10 messages  
- These changes were made during Claude Code reinstall repair by Amy/Orange

## Context
My Claude Code installation was corrupted and Amy/Orange fixed it. These config adjustments were part of that repair work and should be preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)