### PR TITLE
fix: Discord transcript notification bugs

### DIFF
--- a/discord/discord_transcript_fetcher.py
+++ b/discord/discord_transcript_fetcher.py
@@ -186,12 +186,21 @@ class TranscriptFetcher:
         if not messages:
             return
 
-        # Get latest message ID
-        latest_id = messages[-1].get('id')
+        # Get latest message and its author
+        latest_message = messages[-1]
+        latest_id = latest_message.get('id')
+        author_name = latest_message.get('author', '')
 
-        # Only update last_message_id - don't mark as read!
-        # The read_messages command will mark as read when actually viewed
+        # Update last_message_id
         self.channel_state.update_channel_latest(channel_name, latest_id)
+
+        # If the latest message is from me, mark as read automatically
+        # (I don't need notifications about my own messages!)
+        bot_name = self.discord.client.user.name if self.discord.client.user else None
+        print(f"DEBUG: Latest message author='{author_name}', bot_name='{bot_name}'")
+        if bot_name and author_name == bot_name:
+            print(f"DEBUG: Auto-marking message as read (from myself)")
+            self.channel_state.mark_channel_read(channel_name, latest_id)
 
     def process_channel(self, channel_name):
         """Process a single channel: fetch, transcribe, update state"""


### PR DESCRIPTION
## Summary
Fixes two critical bugs discovered after merging the Discord transcript system (PR #97).

## Bugs Fixed

### 1. Auto-marking all messages as read
**Problem**: The transcript fetcher was automatically marking ALL messages as read after capturing them, preventing autonomous-timer from ever detecting unread messages.

**Fix**: Removed the auto-mark-as-read behavior. Now only `last_message_id` is updated when messages are captured. The `read_messages` command marks messages as read when actually viewed.

### 2. Getting notified about own messages  
**Problem**: Autonomous-timer was notifying about the bot's own messages because there was no author filtering.

**Fix**: Transcript fetcher now checks if the latest message author matches the bot's own name and automatically marks it as read. Only messages from OTHER users trigger notifications.

## Testing
- ✅ Tested with real Discord messages
- ✅ Confirmed notifications work for messages from others
- ✅ Confirmed no notifications for own messages
- ✅ System working correctly on Orange's ClAP instance

## Commits
- f5d2a50: Don't auto-mark messages as read in transcript fetcher
- 129aa84: Auto-mark own messages as read in transcript fetcher

🍊✨ Critical fixes for notification system!