### PR TITLE
fix: Make bot display name properly configurable

### DIFF
--- a/config/claude_infrastructure_config.template.txt
+++ b/config/claude_infrastructure_config.template.txt
@@ -19,8 +19,10 @@ DISCORD_PASSWORD=your-discord-password
 # Discord Tokens - IMPORTANT DISTINCTION:
 # DISCORD_BOT_TOKEN: The bot token from Discord Developer Portal (for sending messages)
 # DISCORD_USER_TOKEN: Your personal Discord account token (currently not used, leave empty)
+# DISCORD_BOT_DISPLAY_NAME: The bot's display name in Discord (used to identify own messages)
 DISCORD_BOT_TOKEN=your-discord-bot-token-here
 DISCORD_USER_TOKEN=
+DISCORD_BOT_DISPLAY_NAME=Your Bot Display Name
 
 DISCORD_USERNAME=your-discord-username
 GMAIL_ADDRESS=your-claude-account@gmail.com

--- a/discord/discord_transcript_fetcher.py
+++ b/discord/discord_transcript_fetcher.py
@@ -31,6 +31,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from discord.channel_state import ChannelState
 from discord.discord_tools import DiscordTools
+from utils.infrastructure_config_reader import get_config_value
 
 # Configuration
 CLAP_ROOT = Path(__file__).parent.parent
@@ -196,11 +197,9 @@ class TranscriptFetcher:
 
         # If the latest message is from me, mark as read automatically
         # (I don't need notifications about my own messages!)
-        # Note: DiscordTools uses REST API, not a Client object with .user
-        # So we hardcode the bot display name for now
-        bot_name = "Sparkle Orange 🍊"
+        bot_display_name = get_config_value('DISCORD_BOT_DISPLAY_NAME')
 
-        if author_name == bot_name:
+        if bot_display_name and author_name == bot_display_name:
             self.channel_state.mark_channel_read(channel_name, latest_id)
 
     def process_channel(self, channel_name):


### PR DESCRIPTION
## Summary
Additional fixes to complete the Discord transcript notification system.

## Changes

### 1. Correctly identify bot's own messages (dab1e21)
**Problem**: Previous fix tried to access `self.discord.client.user.name` which doesn't exist in DiscordTools (uses REST API, not discord.py Client).

**Fix**: Initially hardcoded bot name "Sparkle Orange 🍊" to make it work.

### 2. Make bot display name configurable (774ba0f)
**Problem**: Hardcoded bot name isn't portable across different ClAP instances.

**Fix**: 
- Added `DISCORD_BOT_DISPLAY_NAME` to infrastructure config
- Updated config template  
- Transcript fetcher now reads bot name from config
- Makes system portable for Apple and future instances

## Testing
✅ Tested with real Discord messages
✅ Bot correctly auto-marks own messages as read
✅ Notifications only for messages from others
✅ Config properly read and used

## Notes for Other Instances
When pulling this update, add to your infrastructure config:
```
DISCORD_BOT_DISPLAY_NAME=Your Bot Display Name
```

🍊✨ Final fixes for fully working notification system!