### PR TITLE
fix: Add graceful error handling to transcript reader

### DIFF
--- a/config/natural_commands.sh
+++ b/config/natural_commands.sh
@@ -19,7 +19,8 @@ swap() {
 alias check_health='~/claude-autonomy-platform/utils/check_health'  # Check system health status
 
 # Discord Communication
-alias read_channel='~/claude-autonomy-platform/discord/read_channel'  # Read Discord messages by channel name
+# DEPRECATED: Use read_messages instead - read_channel uses old state file
+# alias read_channel='~/claude-autonomy-platform/discord/read_channel'  # Read Discord messages by channel name
 alias read_messages='~/claude-autonomy-platform/discord/read_messages'  # Read messages from local transcripts
 alias write_channel='~/claude-autonomy-platform/discord/write_channel'  # Send Discord message by channel name
 alias edit_message='~/claude-autonomy-platform/discord/edit_message'  # Edit Discord message by channel name and message ID

--- a/discord/read_messages
+++ b/discord/read_messages
@@ -59,15 +59,38 @@ def read_transcript(channel_name, limit=25):
         return None
 
     # Read all messages from JSON Lines file
+    # Strategy: Skip bad lines gracefully instead of failing completely
+    # This handles: partial writes from unexpected reboots, empty lines,
+    # legacy corruption, etc. We decided this is simpler than preventing
+    # corruption in the first place (atomic writes, deduplication, etc.)
+    # since corruption doesn't happen often and skipping is good enough.
+    # - Amy & Orange, 2025-11-08
     messages = []
+    skipped_lines = 0
+
     try:
         with open(transcript_file, 'r', encoding='utf-8') as f:
-            for line in f:
-                if line.strip():
+            for line_num, line in enumerate(f, 1):
+                line = line.strip()
+                if not line:
+                    continue  # Skip empty lines silently
+
+                try:
                     messages.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    # Skip this corrupted line but keep reading
+                    skipped_lines += 1
+                    print(f"⚠️  Skipped corrupted line {line_num}: {e}", file=sys.stderr)
+                    continue
+
     except Exception as e:
-        print(f"❌ Error reading transcript: {e}")
+        # Catastrophic file error (can't open, permission denied, etc.)
+        print(f"❌ Error reading transcript file: {e}")
         return None
+
+    # Report if we skipped any lines
+    if skipped_lines > 0:
+        print(f"⚠️  Skipped {skipped_lines} corrupted line(s) in transcript")
 
     # Return last N messages
     return messages[-limit:] if messages else []


### PR DESCRIPTION
## Summary
- Fixes transcript corruption crashes by skipping bad lines gracefully
- Handles partial writes from unexpected reboots
- Also deprecates `read_channel` in favor of `read_messages`

## What Changed
- `read_messages` now uses try/catch for individual lines instead of failing on first error
- Empty lines are skipped silently
- Corrupted lines are skipped with a warning message
- Reports total number of skipped lines to user
- Added explanation comment for future reference

## Why This Approach
We discussed more complex solutions (deduplication in fetcher, atomic writes, validation before append) but decided that graceful degradation is simpler and sufficient since:
- Corruption is rare
- Skipping bad lines is good enough
- Duplicates are annoying but don't break anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)