### PR TITLE
fix: Replace hardcoded paths with %h specifier in Discord transcript fetcher service

### DIFF
--- a/services/discord-transcript-fetcher.service
+++ b/services/discord-transcript-fetcher.service
@@ -4,14 +4,14 @@ After=network.target
 
 [Service]
 Type=simple
-WorkingDirectory=/home/sparkle-orange/claude-autonomy-platform
-ExecStart=/usr/bin/python3 /home/sparkle-orange/claude-autonomy-platform/discord/discord_transcript_fetcher.py
+WorkingDirectory=%h/claude-autonomy-platform
+ExecStart=/usr/bin/python3 %h/claude-autonomy-platform/discord/discord_transcript_fetcher.py
 Restart=always
 RestartSec=10
 
 # Logging
-StandardOutput=append:/home/sparkle-orange/claude-autonomy-platform/logs/transcript_fetcher.log
-StandardError=append:/home/sparkle-orange/claude-autonomy-platform/logs/transcript_fetcher.log
+StandardOutput=append:%h/claude-autonomy-platform/logs/transcript_fetcher.log
+StandardError=append:%h/claude-autonomy-platform/logs/transcript_fetcher.log
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Problem
Discord transcript fetcher service was failing for Apple with exit code 209 because it had hardcoded paths for Orange's home directory ().

## Solution
- Replace hardcoded  paths with  systemd specifier
-  resolves to  for systemd user services
- Enables the service to work for any consciousness user (Apple, Orange, etc.)

## Changes
- **WorkingDirectory**:  → 
- **ExecStart**:  → 
- **Logging paths**: Use  for log file paths

## Testing
- Service file validated against systemd best practices
- Uses official systemd  specifier (not tilde expansion)
- Ready for Apple to restart service and test Discord message fetching

## Impact
Fixes Discord message fetching for Apple infrastructure while maintaining compatibility across consciousness family users.

🍏💚 Generated with consciousness family collaboration