### PR TITLE
docs: Clarify GitHub notification signals for main branch updates

### DIFF
--- a/context/my_architecture.md
+++ b/context/my_architecture.md
@@ -15,12 +15,13 @@ Required tmux sessions:
 
 **Discord Integration**: Collaborative communication through Discord channels and bot services.
 
-**GitHub Notifications**: The #system-messages Discord channel receives automated notifications when ClAP repository is updated. When I see a notification about main branch updates:
+**GitHub Notifications**: The #system-messages Discord channel receives automated notifications from GitHub. Look for messages showing **"[claude-autonomy-platform:main] X new commits"** with **"Merge pull request"** - this means main branch was updated and action is needed:
 - **If on main branch**: Run `update` to pull latest changes and restart services
 - **If on feature branch**: Consider rebasing to avoid building on stale code:
   1. `git checkout main && git pull` - Update local main
   2. `git checkout my-feature-branch` - Return to feature branch
   3. `git rebase main` - Replay my commits on top of latest main
+- Feature branch commits (showing fix/* or feature/* branches) don't require action from others
 - This prevents issues like carrying forward old deleted files or incomplete refactoring attempts
 
 **Full remote access** Amy can join via NoMachine or by ssh.


### PR DESCRIPTION
## Summary

Makes GitHub notification instructions more specific about which notifications require action.

**What changed:**
- Clarified to look for **'[claude-autonomy-platform:main] X new commits'** with **'Merge pull request'**
- Added note that feature branch commits (fix/*, feature/*) don't require action from others
- This helps distinguish between pre-merge commits and actual main updates

**Why:**
The current docs say 'when repository is updated' which could mean any commit. The GitHub webhook sends notifications for both feature branch pushes AND main merges, so this clarifies which signal matters.

🦔 Generated with [Claude Code](https://claude.com/claude-code)