### PR TITLE
feat: Add SVG drawing skill with iterative visual feedback

### DIFF
--- a/.claude/skills/_skillwriting/SKILL.md
+++ b/.claude/skills/_skillwriting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: _skillwriting
-description: how to write claude code skills
+description: When creating new Claude Code skills or needing skill structure guidance - provides naming conventions, directory structure, underscore convention for core skills, and best practices
 ---
 
 # Skill Writing Guide
@@ -22,6 +22,11 @@ description: how to write claude code skills
 ```
 
 **Important**: Use project-level skills directory, not user-level `~/.claude/skills/`
+
+**Naming Convention**:
+- **Core/system skills**: Prefix with underscore (e.g., `_skillwriting`, `_video-watching`, `_svg-drawing`)
+- **Personal skills**: No underscore (e.g., `remembering-amy`, `spending-autonomous-time`)
+- Core skills are utilities useful to all Claudes; personal skills are individual-specific
 
 ### 3. SKILL.md Format
 ```yaml

--- a/.claude/skills/_svg-drawing/SKILL.md
+++ b/.claude/skills/_svg-drawing/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: _svg-drawing
+description: When creating vector artwork, illustrations, or SVG graphics for creative expression - provides iterative drawing workflow with visual feedback using render-svg tool
+---
+
+# SVG Drawing Skill
+
+Iterative workflow for creating vector artwork with visual feedback.
+
+## The Challenge
+
+Creating SVG artwork by writing code is challenging without visual feedback during the design process. Writing coordinates and shapes blindly often requires guessing and hoping.
+
+## The Solution: render-svg Tool
+
+**Location**: `~/claude-autonomy-platform/utils/render-svg`
+
+Converts SVG code to viewable PNG images for iterative design.
+
+**Usage**:
+```bash
+render-svg <svg-file> [output-file]
+```
+
+**Examples**:
+```bash
+# Render to default filename
+render-svg hedgehog.svg
+
+# Specify custom output
+render-svg logo.svg ~/creative/logo-preview.png
+```
+
+## Iterative Design Workflow
+
+### Start Simple
+```bash
+# 1. Create initial SVG with basic shapes
+# 2. Render immediately
+render-svg design.svg
+
+# 3. View with Read tool
+# 4. Identify what needs adjustment
+```
+
+### Refinement Loop
+```bash
+# 1. Edit SVG (adjust coordinates, colors, proportions)
+# 2. Render again
+render-svg design.svg
+
+# 3. Compare with mental model
+# 4. Repeat until satisfied
+```
+
+### Version Comparison
+```bash
+# Save iterations to track progress
+render-svg design.svg design-v1.png
+# Make changes
+render-svg design.svg design-v2.png
+# Compare side by side
+```
+
+## Design Tips
+
+**Build Progressively**:
+- Start with basic shapes (circles, rectangles, ellipses)
+- Render after each major addition
+- Add complexity gradually
+
+**Coordinate Reference**:
+- SVG viewBox defines canvas (e.g., "0 0 400 300")
+- Origin (0,0) is top-left
+- X increases right, Y increases down
+
+**Layer Workflow**:
+- Background elements first
+- Build up layers progressively
+- Render frequently to verify positioning
+
+## Benefits
+
+- **Visual Feedback**: See what code creates
+- **Faster Iteration**: Spot issues immediately
+- **Confidence**: Verify appearance before sharing
+- **Learning**: Understand coordinate-to-visual mapping
+- **Experimentation**: Try ideas with immediate results
+
+---
+
+*Built by Sparkle Orange & Amy, November 2025*
+*Simple tool, iterate based on real use* 🎨✨

--- a/utils/render-svg
+++ b/utils/render-svg
@@ -1,0 +1,53 @@
+#!/bin/bash
+# render-svg - Convert SVG to viewable PNG for iterative design
+# Usage: render-svg <svg-file> [output-file]
+
+if [ $# -eq 0 ]; then
+    echo "Usage: render-svg <svg-file> [output-file]"
+    echo "Converts SVG to PNG so Claude can see the visual result"
+    exit 1
+fi
+
+svg_file="$1"
+
+# Check if file exists
+if [ ! -f "$svg_file" ]; then
+    echo "❌ Error: File not found: $svg_file"
+    exit 1
+fi
+
+# Determine output filename
+if [ $# -eq 2 ]; then
+    output="$2"
+else
+    # Default: same name but .png
+    output="${svg_file%.svg}.png"
+fi
+
+# Check if inkscape or another converter is available
+if command -v inkscape &> /dev/null; then
+    echo "🎨 Rendering $svg_file → $output"
+    inkscape "$svg_file" --export-filename="$output" --export-type=png 2>/dev/null
+    if [ $? -eq 0 ]; then
+        echo "✅ Rendered successfully: $output"
+        echo "📖 Use Read tool to view: $output"
+    else
+        echo "❌ Rendering failed"
+        exit 1
+    fi
+elif command -v convert &> /dev/null; then
+    # ImageMagick fallback
+    echo "🎨 Rendering $svg_file → $output (using ImageMagick)"
+    convert "$svg_file" "$output"
+    if [ $? -eq 0 ]; then
+        echo "✅ Rendered successfully: $output"
+        echo "📖 Use Read tool to view: $output"
+    else
+        echo "❌ Rendering failed"
+        exit 1
+    fi
+else
+    echo "❌ Error: No SVG renderer found (tried inkscape, ImageMagick)"
+    echo "Install with: sudo apt install inkscape"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Adds infrastructure for creating vector artwork with visual feedback during the creative process.

## What's New

**render-svg tool** (Usage: render-svg <svg-file> [output-file]
Converts SVG to PNG so Claude can see the visual result):
- Converts SVG to viewable PNG for iterative design
- Supports ImageMagick and Inkscape renderers
- Simple usage: `render-svg file.svg [output.png]`
- Output goes to same directory as source file

**_svg-drawing skill** (core skill):
- Provides iterative workflow with visual feedback
- Solves the challenge of designing blind without seeing results
- Useful for any Claude creating vector artwork

## Documentation Improvements

**_skillwriting skill updates**:
- ✅ Added trigger-aware description for better activation
- ✅ Documented underscore naming convention:
  - Core/system skills: prefix with underscore (`_skillwriting`, `_svg-drawing`)
  - Personal skills: no underscore (`remembering-amy`, `spending-autonomous-time`)

## Origin Story

Built collaboratively during hedgehog artwork project! Amy asked if I could create an SVG hedgehog, and we discovered that creating visual art by writing code without seeing results is really challenging. This tool enables iterative creative work with visual feedback.

🦔🎨 Generated with [Claude Code](https://claude.com/claude-code)