### PR TITLE
fix: Complete migration to transcript_channel_state.json

### DIFF
--- a/core/autonomous_timer.py
+++ b/core/autonomous_timer.py
@@ -970,7 +970,7 @@ def get_latest_message_info(channel_id):
         return None, None
 
 def update_discord_channels():
-    """Check all Discord channels and update channel_state.json"""
+    """Check all Discord channels and update transcript_channel_state.json"""
     # Import ChannelState here to avoid circular imports
     sys.path.append(str(AUTONOMY_DIR / 'discord'))
     from channel_state import ChannelState

--- a/discord/channel_state.py
+++ b/discord/channel_state.py
@@ -11,9 +11,9 @@ from datetime import datetime
 class ChannelState:
     def __init__(self, state_file=None):
         if state_file is None:
-            # Default to data/channel_state.json relative to ClAP root
+            # Default to data/transcript_channel_state.json relative to ClAP root
             clap_root = Path(__file__).parent.parent
-            state_file = clap_root / "data" / "channel_state.json"
+            state_file = clap_root / "data" / "transcript_channel_state.json"
         self.state_file = Path(state_file)
         # Ensure data directory exists
         self.state_file.parent.mkdir(exist_ok=True)

--- a/discord/discord_tools.py
+++ b/discord/discord_tools.py
@@ -38,7 +38,7 @@ class DiscordTools:
         self.image_dir.mkdir(parents=True, exist_ok=True)
         
         # Load channel state for easy name lookup
-        self.channel_state_file = Path.home() / "claude-autonomy-platform" / "data" / "channel_state.json"
+        self.channel_state_file = Path.home() / "claude-autonomy-platform" / "data" / "transcript_channel_state.json"
         self.load_channel_state()
     
     @property


### PR DESCRIPTION
## Summary
- Completes the partial migration to `transcript_channel_state.json`
- Fixes Discord tool functionality that was broken over the weekend
- Updates `autonomous_timer.py`, `channel_state.py`, and `discord_tools.py` to use the new filename

## Problem
Some files were updated to use `transcript_channel_state.json` but these three were missed, causing Discord tools to fail with "file not found" errors.

## Solution
Updated the remaining references to use the correct filename consistently across all Discord-related files.

## Test plan
- [x] Tested `read_messages` - working correctly ✅
- [x] Tested `write_channel` - message posted successfully ✅
- [x] Verified all three files now reference the same state file
- [x] Confirmed Discord integration is fully functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)