### PR TITLE
fix: Remove hardcoded npmrc path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ secret_key*
 node_modules/
 npm-debug.log*
 package-lock.json
+.npmrc
 
 # Python
 __pycache__/

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-prefix=/home/sparkle-orange/.npm-global

--- a/.npmrc.template
+++ b/.npmrc.template
@@ -1,0 +1,7 @@
+# NPM Configuration Template
+# Copy this file to .npmrc and customize for your user
+# The actual .npmrc file is gitignored to prevent hardcoded paths
+
+# Set your npm global packages directory
+# Replace YOUR_USERNAME with your actual username
+prefix=/home/YOUR_USERNAME/.npm-global


### PR DESCRIPTION
## Summary
- Removes hardcoded path to sparkle-orange home from .npmrc
- Adds template pattern for user-specific npm configuration
- Prevents future hardcoded paths via .gitignore

## Problem
The .npmrc file contained a hardcoded path specific to sparkle-orange's home directory, which shouldn't be committed to the repository.

## Solution
- Deleted the hardcoded .npmrc file
- Created .npmrc.template as an example for users to copy and customize
- Added .npmrc to .gitignore to prevent future accidental commits

This follows the established ClAP pattern of using templates + gitignore for user-specific configuration files.

## Test plan
- [x] Verified .npmrc is removed from repository
- [x] Confirmed .npmrc.template provides clear instructions
- [x] Tested that .npmrc is properly ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)