### PR TITLE
fix: Make transcript fetcher track all channels automatically

### DIFF
--- a/discord/discord_transcript_fetcher.py
+++ b/discord/discord_transcript_fetcher.py
@@ -59,16 +59,17 @@ class TranscriptFetcher:
         # Get Discord tools instance (includes attachment handling)
         self.discord = DiscordTools()
 
-        # Load channel configuration from my_discord_channels.json
-        channels_config_file = CLAP_ROOT / "config" / "my_discord_channels.json"
-        if channels_config_file.exists():
-            with open(channels_config_file, 'r') as f:
-                channels_config = json.load(f)
-                self.channels_to_track = channels_config.get('channels', ['general'])
-        else:
-            # Fallback to just general if config doesn't exist
+        # Track ALL channels that exist in the channel state
+        # This automatically includes any new channels as they're discovered
+        all_channels = self.channel_state.state.get('channels', {})
+        self.channels_to_track = list(all_channels.keys())
+
+        # If no channels exist yet, start with general
+        if not self.channels_to_track:
             self.channels_to_track = ['general']
-            print("⚠️  No my_discord_channels.json found, defaulting to ['general']")
+            print("⚠️  No channels in state yet, starting with ['general']")
+        else:
+            print(f"📡 Tracking {len(self.channels_to_track)} channels from state")
 
     def initialize_channels(self):
         """Initialize tracked channels if not already in state"""


### PR DESCRIPTION
## Summary
- Removes dependency on my_discord_channels.json config file
- Makes transcript fetcher automatically track ALL channels from transcript_channel_state.json
- Completes the consolidation to a single source of truth

## Problem
The transcript fetcher was only tracking channels listed in my_discord_channels.json, which meant:
- New channels weren't automatically picked up
- Manual config was needed for each channel
- We had multiple competing channel lists

## Solution
Modified the fetcher to automatically use all channels from transcript_channel_state.json. This means:
- All existing channels are tracked
- New channels are automatically included
- No manual configuration needed
- Single source of truth for channel tracking

## Test plan
- [x] Tested with delta-quill channel
- [x] Verified fetcher tracks all 7 channels
- [x] Confirmed transcripts are created for new messages
- [x] Checked logs show "Tracking 7 channels from state"

🤖 Generated with [Claude Code](https://claude.com/claude-code)