### PR TITLE
Make webhook host configurable for resource tracking

### DIFF
--- a/config/claude_infrastructure_config.template.txt
+++ b/config/claude_infrastructure_config.template.txt
@@ -88,5 +88,11 @@ SESSION_SWAP_MONITOR=session-swap-monitor.service
 [USER_CONFIG]
 HISTORY_TURNS=20
 
+[RESOURCE_SHARE]
+# Webhook host for resource tracking
+# For the main instance running the webhook server: localhost
+# For remote instances connecting to the webhook: IP address of webhook server (e.g., 192.168.1.2)
+WEBHOOK_HOST=localhost
+
 # This file should be sourced by setup scripts to ensure consistency
 # across all configuration files and installations

--- a/core/autonomous_timer.py
+++ b/core/autonomous_timer.py
@@ -48,7 +48,8 @@ RESOURCE_TRACKING_STATE_FILE = DATA_DIR / "last_cache_tokens.json"
 (AUTONOMY_DIR / "logs").mkdir(exist_ok=True)
 
 # Resource-share webhook configuration
-RESOURCE_SHARE_WEBHOOK_URL = "http://localhost:8765/resource-share/increment"
+WEBHOOK_HOST = get_config_value("WEBHOOK_HOST", "localhost")
+RESOURCE_SHARE_WEBHOOK_URL = f"http://{WEBHOOK_HOST}:8765/resource-share/increment"
 
 # Discord API configuration
 DISCORD_API_BASE = "https://discord.com/api/v10"


### PR DESCRIPTION
## Summary
Makes the webhook host configurable for resource tracking, allowing remote Claude instances (Delta, Apple) to connect to Orange's webhook server.

## Changes
- Added `WEBHOOK_HOST` config option to `[RESOURCE_SHARE]` section in infrastructure config
- Updated `autonomous_timer.py` to read webhook host from config instead of hardcoded `localhost`
- Updated config template with documentation

## Configuration
- **Orange (webhook server)**: `WEBHOOK_HOST=localhost`
- **Apple/Delta (remote instances)**: `WEBHOOK_HOST=192.168.1.2`

## Testing
- Verified config reading works correctly
- Orange's config reads `localhost` as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)