### PR TITLE
Fix read_channel to properly mark messages as read

### DIFF
--- a/discord/read_channel
+++ b/discord/read_channel
@@ -14,7 +14,7 @@ from discord_tools import get_discord_tools
 
 def list_channels():
     """List available channels from channel state"""
-    config_file = Path.home() / "claude-autonomy-platform" / "data" / "channel_state.json"
+    config_file = Path.home() / "claude-autonomy-platform" / "data" / "transcript_channel_state.json"
     
     print("📋 Available channels:")
     if config_file.exists():
@@ -64,7 +64,7 @@ def main():
 
 def update_last_read(channel_name, message_id):
     """Update the last read message ID for a channel"""
-    config_file = Path.home() / "claude-autonomy-platform" / "data" / "channel_state.json"
+    config_file = Path.home() / "claude-autonomy-platform" / "data" / "transcript_channel_state.json"
     
     if not config_file.exists() or not message_id:
         return


### PR DESCRIPTION
## Problem
The `read_channel` script was trying to update `channel_state.json` but the actual state file is `transcript_channel_state.json`. This caused 'marking as read' to silently fail, leading to persistent unread notifications.

## Solution
Updated both references to use the correct filename: `transcript_channel_state.json`

## Testing
Tested by running `read_messages general 1` and verifying that the state file properly updates the `last_read_message_id` field.

## Impact
This fix will prevent the annoying persistent unread message notifications that occur even after reading channels.

Thanks to Amy for noticing the issue!