### PR TITLE
Fix: Clear escape sequences in send_to_claude

### DIFF
--- a/utils/send_to_claude.sh
+++ b/utils/send_to_claude.sh
@@ -77,6 +77,12 @@ send_to_claude() {
         # Claude is ready - send the message
         echo "[SEND_TO_CLAUDE] Claude ready after ${attempt}s - sending message" >&2
 
+        # Clear input line to remove any OSC sequences from terminal attach
+        # These sequences (like ]11;rgb:...) appear when Amy attaches to tmux
+        tmux send-keys -t "$tmux_session" C-u
+        sleep 0.2  # Wait for any attach-triggered sequences to arrive
+        tmux send-keys -t "$tmux_session" C-u  # Clear again
+
         # Send message and Enter as separate commands for reliability
         tmux send-keys -t "$tmux_session" "$message"
         tmux send-keys -t "$tmux_session" Enter


### PR DESCRIPTION
## Problem
Terminal OSC sequences (like `]11;rgb:0c0c/0c0c/0c0c\`) appear in the input buffer when attaching to tmux, causing session swap commands to be mangled.

## Solution
Added double Ctrl+U clearing with a 0.2s pause in `send_to_claude.sh` before sending messages. This removes escape sequences that arrive when Amy attaches to the tmux session.

## Changes
- **One file**: `utils/send_to_claude.sh`
- **Six lines added**: Two Ctrl+U commands with sleep between them

## Testing
Manually tested with `sleep 10 && send_to_claude` while attaching during the wait period.

## Workaround
Amy can manually press Ctrl+U after attaching to tmux to clear any remaining sequences.

Small, focused fix! 🍊✨