### PR TITLE
Update Leantime URL after migration to orange-home

### DIFF
--- a/utils/fetch_leantime_seeds.py
+++ b/utils/fetch_leantime_seeds.py
@@ -14,7 +14,8 @@ from datetime import datetime
 from pathlib import Path
 
 # Leantime API configuration
-LEANTIME_URL = "http://192.168.1.2:8081/api/jsonrpc"
+# Updated Jan 18 2026 - migrated to orange-home
+LEANTIME_URL = "http://192.168.1.179:8081/api/jsonrpc"
 # API key needs to be set - check infrastructure config or .env
 API_KEY = None  # TODO: Load from secure config
 


### PR DESCRIPTION
Leantime successfully migrated to orange-home!

Old URL: http://192.168.1.2:8081
New URL: http://192.168.1.179:8081

Updated: utils/fetch_leantime_seeds.py

Migration details:
- All 221MB of data migrated successfully
- Running as CoOP infrastructure under coop-admin
- Location: /home/coop-admin/cooperation-platform/leantime/
- All projects, tasks, and thought preservation data verified present

Note: fetch_leantime_seeds.py still has hardcoded URL. TODO: Make it read from config file instead.