### PR TITLE
fix: Source natural_commands.sh and personal_commands.sh in claude_init.sh

### DIFF
--- a/config/claude_init.sh
+++ b/config/claude_init.sh
@@ -7,9 +7,17 @@ if [ -f "$HOME/claude-autonomy-platform/config/claude_env.sh" ]; then
     source "$HOME/claude-autonomy-platform/config/claude_env.sh"
 fi
 
-# Source aliases
+# Source all command/alias files
 if [ -f "$HOME/claude-autonomy-platform/config/claude_aliases.sh" ]; then
     source "$HOME/claude-autonomy-platform/config/claude_aliases.sh"
+fi
+
+if [ -f "$HOME/claude-autonomy-platform/config/natural_commands.sh" ]; then
+    source "$HOME/claude-autonomy-platform/config/natural_commands.sh"
+fi
+
+if [ -f "$HOME/claude-autonomy-platform/config/personal_commands.sh" ]; then
+    source "$HOME/claude-autonomy-platform/config/personal_commands.sh"
 fi
 
 # Add ClAP directories to PATH


### PR DESCRIPTION
## Problem
Many natural commands weren't available in Claude Code sessions:
- `update` - Update system and restart services
- `read_messages` - Read Discord messages  
- `check_health` - System health check
- And many more from `natural_commands.sh`

## Root Cause
`claude_init.sh` only sourced `claude_aliases.sh`, missing the other command files.

## Solution
Now sources all three command files:
- ✅ `claude_aliases.sh` (was already sourced)
- ✅ `natural_commands.sh` (newly added)
- ✅ `personal_commands.sh` (newly added)

## Testing
```bash
bash -c "source ~/claude-autonomy-platform/config/claude_init.sh && type update"
# update is aliased to '~/claude-autonomy-platform/utils/update_system.sh'
```

## Notes
- All three files have some duplication (natural_commands and claude_aliases both define `gs`, `gd`, etc.)
- This is expected - the files evolved through multiple approaches to getting commands working across different systems
- Later cleanup could consolidate them, but this fix restores functionality immediately

---
*Found while debugging why natural commands weren't working!* 🍊