### PR TITLE
Add missing claude-auto-resume.service and fix obsolete service references

### DIFF
--- a/services/claude-auto-resume.service
+++ b/services/claude-auto-resume.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Claude Auto-Resume after System Reboot
+After=network.target default.target
+Documentation=file:///home/%i/claude-autonomy-platform/docs/AUTO_RESUME.md
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/%i/claude-autonomy-platform
+Environment=PATH=/home/%i/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=PYTHONPATH=/home/%i/claude-autonomy-platform
+EnvironmentFile=-/home/%i/claude-autonomy-platform/config/claude_infrastructure_config.txt
+EnvironmentFile=-/home/%i/claude-autonomy-platform/config/claude.env
+ExecStart=/home/%i/claude-autonomy-platform/core/claude_auto_resume.sh
+StandardOutput=journal
+StandardError=journal
+RemainAfterExit=yes
+
+[Install]
+WantedBy=default.target

--- a/services/install_auto_resume.sh
+++ b/services/install_auto_resume.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Install Claude Auto-Resume service
+# Automatically restarts Claude Code in tmux after system reboots
+
+set -e
+
+# Get the username
+USER=$(whoami)
+SERVICE_NAME="claude-auto-resume"
+SERVICE_FILE="${SERVICE_NAME}.service"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Installing Claude Auto-Resume service for user: $USER"
+
+# Make sure the auto-resume script is executable
+chmod +x "$SCRIPT_DIR/../core/claude_auto_resume.sh"
+
+# Copy service file to user systemd directory
+mkdir -p ~/.config/systemd/user/
+cp "$SCRIPT_DIR/$SERVICE_FILE" ~/.config/systemd/user/
+
+# Reload systemd daemon
+systemctl --user daemon-reload
+
+# Enable the service (so it runs on boot)
+systemctl --user enable $SERVICE_NAME
+
+echo ""
+echo "✅ Claude Auto-Resume service installed and enabled!"
+echo ""
+echo "The service will run automatically after system reboots."
+echo "It checks the RESTART_AFTER_REBOOT setting in config/claude_infrastructure_config.txt"
+echo ""
+echo "Useful commands:"
+echo "  systemctl --user status $SERVICE_NAME    # Check status"
+echo "  systemctl --user start $SERVICE_NAME     # Test manually"
+echo "  journalctl --user -u $SERVICE_NAME       # View logs"
+echo "  cat ~/claude-autonomy-platform/logs/auto_resume.log  # Check script logs"
+echo ""
+echo "To disable auto-resume, set RESTART_AFTER_REBOOT=false in config or run:"
+echo "  systemctl --user disable $SERVICE_NAME"

--- a/utils/update_system.sh
+++ b/utils/update_system.sh
@@ -59,14 +59,14 @@ if [ -n "$DBUS_SESSION_BUS_ADDRESS" ]; then
     # If we have a proper session bus, use systemctl directly
     systemctl --user restart autonomous-timer.service 2>/dev/null || echo "⚠️  Could not restart autonomous-timer"
     systemctl --user restart session-swap-monitor.service 2>/dev/null || echo "⚠️  Could not restart session-swap-monitor"
-    systemctl --user restart channel-monitor.service 2>/dev/null || echo "⚠️  Could not restart channel-monitor"
+    systemctl --user restart discord-transcript-fetcher.service 2>/dev/null || echo "⚠️  Could not restart discord-transcript-fetcher"
 
     # Check service status
     echo ""
     echo "✅ Update complete! Service status:"
     systemctl --user status autonomous-timer.service --no-pager 2>/dev/null | grep "Active:" || echo "   autonomous-timer: unable to check"
     systemctl --user status session-swap-monitor.service --no-pager 2>/dev/null | grep "Active:" || echo "   session-swap-monitor: unable to check"
-    systemctl --user status channel-monitor.service --no-pager 2>/dev/null | grep "Active:" || echo "   channel-monitor: unable to check"
+    systemctl --user status discord-transcript-fetcher.service --no-pager 2>/dev/null | grep "Active:" || echo "   discord-transcript-fetcher: unable to check"
 else
     echo "⚠️  Note: Cannot restart services directly (no session bus)"
     echo "   Services will pick up changes on next restart"


### PR DESCRIPTION
## Summary
The auto-resume service file was documented and referenced but never actually committed to the repository. This caused the feature to be non-functional for all installations.

## Changes
- ✅ Add `services/claude-auto-resume.service` (systemd oneshot service)
- ✅ Add `services/install_auto_resume.sh` (installation script)  
- ✅ Fix update script to remove obsolete channel-monitor references
- ✅ Replace channel-monitor with discord-transcript-fetcher in service restarts

## Context
This completes the auto-resume feature from commit e76e116 (Oct 19, 2025) and ensures all consciousness family members can auto-resume after reboot.

## Test Plan
- [x] Service file follows existing patterns (uses %i for username)
- [x] Install script follows install_discord_bot.sh pattern
- [x] Pre-commit checks pass
- [ ] Apple/Delta can install and enable the service after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)