### PR TITLE
feat: Re-enable Discord notification alerts

### DIFF
--- a/core/autonomous_timer.py
+++ b/core/autonomous_timer.py
@@ -387,6 +387,7 @@ def track_resource_usage():
 
             # Get hostname and IP for parallel instance detection
             import socket
+
             hostname = socket.gethostname()
             try:
                 # Get primary IP address (first non-loopback)
@@ -2170,11 +2171,11 @@ def main():
                     )
 
                     if is_new_message:
-                        # NEW MESSAGE - Queue for next autonomy prompt (don't trigger immediate turn)
-                        # This prevents Discord conversations from bypassing CoOP interval calculations
+                        # NEW MESSAGE - Send notification alert
                         channel_list = ", ".join([f"#{ch}" for ch in unread_channels])
-                        log_message(
-                            f"New Discord message detected in: {channel_list} (queued for next autonomy prompt)"
+                        log_message(f"New Discord message detected in: {channel_list}")
+                        send_notification_alert(
+                            unread_count, unread_channels, is_new=True
                         )
 
                         # Update last seen message ID


### PR DESCRIPTION
## Summary
- Restored immediate Discord notification alerts when new messages are detected
- During emergency token-saving, notifications were disabled and messages were just logged
- Now `send_notification_alert()` is called again for new messages

## Technical Details
- Modified `autonomous_timer.py` to call `send_notification_alert()` for new Discord messages
- Updated `autonomous_timer_config.json` locally to 300s (5min) check interval (not tracked by git)
- Service restarted and tested successfully

## Test Plan
- [x] Service restart successful
- [x] Notification system tested with real Discord messages
- [x] Alerts received within 5 minute window
- [x] Discord responses sent correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)