### PR TITLE
chore: Remove deprecated and obsolete settings from infrastructure config template

### DIFF
--- a/config/claude_infrastructure_config.template.txt
+++ b/config/claude_infrastructure_config.template.txt
@@ -13,8 +13,6 @@ LINUX_USER=your-username
 HUMAN_USER=human-username
 PERSONAL_REPO=sonnet-4-home
 CLAUDE_NAME=Your Claude Name
-DISCORD_EMAIL=your-claude-account@gmail.com
-DISCORD_PASSWORD=your-discord-password
 
 # Discord Tokens - IMPORTANT DISTINCTION:
 # DISCORD_BOT_TOKEN: The bot token from Discord Developer Portal (for sending messages)
@@ -24,13 +22,11 @@ DISCORD_BOT_TOKEN=your-discord-bot-token-here
 DISCORD_USER_TOKEN=
 DISCORD_BOT_DISPLAY_NAME=Your Bot Display Name
 
-DISCORD_USERNAME=your-discord-username
 GMAIL_ADDRESS=your-claude-account@gmail.com
 GMAIL_PASSWORD=your-gmail-password
 GMAIL_DOB=dd.mm.yyyy
 HUMAN_PASSWORD=visitclaude
 GIT_USER=your-git-username
-GIT_PASSWORD=your-git-password
 # GitHub Personal Access Token for CLI operations (create at https://github.com/settings/tokens)
 # Required scopes: repo, workflow, read:org (for PR creation and management)
 GITHUB_TOKEN=your-github-personal-access-token
@@ -44,12 +40,9 @@ GOOGLE_CLIENT_SECRET=your-google-client-secret
 GOOGLE_PROJECT_ID=your-google-project-id
 GOOGLE_REDIRECT_URI=http://localhost:3000/oauth2callback
 
-#healthcheck.io urls
-# CHANNEL_MONITOR_PING removed - Discord monitoring now in autonomous-timer
+# healthcheck.io urls
 SESSION_SWAP_PING=https://hc-ping.com/your-session-swap-uuid
 CLAUDE_CODE_PING=https://hc-ping.com/your-claude-code-uuid
-CONTINUITY_BRIDGE_PING=https://hc-ping.com/your-continuity-bridge-uuid
-AUTONOMOUS_TIMER_PING=https://hc-ping.com/your-autonomous-timer-uuid
 
 [PATHS]
 HOME_DIR=/home/$LINUX_USER
@@ -60,30 +53,20 @@ CLAUDE_JSON_PATH=/home/$LINUX_USER/.claude.json
 
 [CORE_MCP_SERVERS]
 # Essential MCP servers that should be in claude-autonomy-platform for all Claude instances
-rag-memory=$AUTONOMY_DIR/mcp-servers/rag-memory-mcp
-discord-mcp=$AUTONOMY_DIR/mcp-servers/discord-mcp
-linear-mcp=$AUTONOMY_DIR/mcp-servers/linear-mcp
+# Variable names must use underscores, not hyphens (bash requirement)
+rag_memory=$AUTONOMY_DIR/mcp-servers/rag-memory-mcp
+linear_mcp=$AUTONOMY_DIR/mcp-servers/linear-mcp
 gmail=$AUTONOMY_DIR/mcp-servers/gmail-mcp
-vscode-mcp=$AUTONOMY_DIR/mcp-servers/vscode-as-mcp-server
+#vscode_mcp=(optional) $AUTONOMY_DIR/mcp-servers/vscode-as-mcp-server
 
 
 [DISCORD_CONFIG]
-DISCORD_HEADLESS=false
-DISCORD_TOKEN_PATH=
 # Discord Bot User ID for message filtering (skip my own messages)
 CLAUDE_DISCORD_USER_ID=your-discord-bot-user-id
 
 [X11_CONFIG]
 DISPLAY=:0
 XAUTH_PATTERN=/run/user/$(id -u)/.mutter-Xwaylandauth.*
-X11_ENV_SCRIPT=$AUTONOMY_DIR/x11_env.sh
-
-[SYSTEM_SERVICES]
-# SystemD user services for autonomy
-AUTONOMOUS_TIMER=autonomous-timer.service
-SESSION_BRIDGE_MONITOR=session-bridge-monitor.service
-SESSION_SWAP_MONITOR=session-swap-monitor.service
-# CHANNEL_MONITOR removed - Discord monitoring now in autonomous-timer
 
 [USER_CONFIG]
 HISTORY_TURNS=20


### PR DESCRIPTION
## Summary
Removed 22 lines of cruft from the infrastructure config template that was causing confusion about which settings are actually used.

## What Was Removed

### Deprecated Credentials
- `DISCORD_EMAIL`, `DISCORD_PASSWORD` - Old Discord login method (replaced by bot tokens)
- `DISCORD_USERNAME` - Never used
- `GIT_PASSWORD` - Replaced by GITHUB_TOKEN

### Puppeteer Hangovers
- `DISCORD_HEADLESS`, `DISCORD_TOKEN_PATH` - Remnants from failed discord-mcp experiment

### Removed Services/Healthchecks
- `SESSION_BRIDGE_MONITOR` service (removed long ago)
- `CONTINUITY_BRIDGE_PING` healthcheck (deprecated)
- `AUTONOMOUS_TIMER_PING` healthcheck (deprecated)
- **Entire `[SYSTEM_SERVICES]` section** - Was just documentation, nothing reads it, already out of date

### Other Cleanup
- `discord-mcp` from MCP servers (replaced by custom discord_tools.py)
- `X11_ENV_SCRIPT` (desktop automation not in use)
- Fixed MCP variable names to use underscores per bash requirement

## Why This Matters
- Reduces confusion about which settings are actually used
- Template now matches current infrastructure reality
- Easier for new instances to know what's required vs obsolete

## Test Plan
- [x] Both template and actual config cleaned identically
- [x] Pre-commit checks pass
- [x] No code references the removed settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)