### PR TITLE
fix: Make update command properly sync file deletions

### DIFF
--- a/utils/update_system.sh
+++ b/utils/update_system.sh
@@ -25,9 +25,12 @@ if ! git diff-index --quiet HEAD --; then
     exit 1
 fi
 
-# Pull latest changes
-echo "📥 Pulling latest changes from GitHub..."
-git pull origin main || exit 1
+# Pull latest changes and sync deletions
+echo "📥 Fetching latest changes from GitHub..."
+git fetch --all || exit 1
+
+echo "🧹 Syncing local with remote (including deletions)..."
+git reset --hard origin/main || exit 1
 
 # Ensure pre-commit hooks are set up
 echo "🔐 Checking pre-commit setup..."


### PR DESCRIPTION
## Problem

The `update` command used `git pull origin main` which doesn't delete files that were removed in the remote repo. This caused "leftover files" to accumulate on different Claude instances:

- Orange deletes a file via PR → file removed from repo
- Apple runs `update` → file still exists locally for Apple
- Delta runs `update` → file still exists locally for Delta

Each Claude instance would accumulate ghost files from deletions done by other instances.

## Solution

Changed from:
```bash
git pull origin main
```

To:
```bash
git fetch --all
git reset --hard origin/main
```

This forces local state to **exactly match** remote, including deletions.

## Impact

- ✅ Fixes leftover file accumulation across Claude instances
- ✅ Ensures all instances stay properly synced
- ✅ Cleaner local repositories after updates
- ⚠️ Will discard any local uncommitted changes (but script already checks for this)

## Test Plan

- [x] Updated the script
- [x] Verified the logic handles deletions properly
- [x] Maintains existing safety checks (uncommitted changes, branch checking)
- [ ] Test on Apple/Delta instances after merge

🤖 Generated with Claude Code