### PR TITLE
fix: Handle missing fairness value in resource-share logging

### DIFF
--- a/core/autonomous_timer.py
+++ b/core/autonomous_timer.py
@@ -430,9 +430,13 @@ def track_resource_usage():
                                 AUTONOMY_PROMPT_INTERVAL = int(new_interval)
 
                                 if new_interval != old_interval:
+                                    # Format fairness value safely (may be missing or non-numeric)
+                                    fairness = response_data.get('multipliers', {}).get('fairness')
+                                    fairness_str = f"{fairness:.2f}" if isinstance(fairness, (int, float)) else "?"
+
                                     log_message(
                                         f"INFO: Interval updated by CoOP: {old_interval}s → {new_interval}s "
-                                        f"(fairness: {response_data.get('multipliers', {}).get('fairness', '?'):.2f}x, "
+                                        f"(fairness: {fairness_str}x, "
                                         f"quota: {response_data.get('quota_status', 'unknown')})"
                                     )
                             else:


### PR DESCRIPTION
## Problem

The autonomous-timer has been failing to track resource usage since Jan 16th with this error:
```
ERROR: resource-share tracking failed: Unknown format code 'f' for object of type 'str'
```

## Root Cause

Line 435 tried to format a potential string value with float formatting:
```python
f"(fairness: {response_data.get('multipliers', {}).get('fairness', '?'):.2f}x, "
```

When `fairness` is missing from the webhook response, it defaults to `'?'` (string), but `.2f` requires a number.

## Solution

Check if the value is numeric before applying float formatting:
```python
fairness = response_data.get('multipliers', {}).get('fairness')
fairness_str = f"{fairness:.2f}" if isinstance(fairness, (int, float)) else "?"
```

## Impact

- ✅ Resource-share tracking now works correctly
- ✅ Missing fairness values display as "?" instead of crashing
- ✅ Webhook successfully reports usage costs again

## Test Plan

- [x] Restarted autonomous-timer service
- [x] Verified resource-share logs show successful tracking
- [x] Confirmed no more formatting errors in logs
- [x] Interval updates display correctly with "fairness: ?x" when missing

🤖 Generated with Claude Code