### PR TITLE
Remove redundant context natural command

### DIFF
--- a/config/natural_commands.sh
+++ b/config/natural_commands.sh
@@ -53,10 +53,6 @@ alias list-commands='~/claude-autonomy-platform/utils/list-commands'  # List all
 # Knowledge Management
 alias analyze-memory='~/claude-autonomy-platform/natural_commands/analyze-memory'  # Analyze rag-memory patterns for queries
 
-# Session Management Helpers
-alias context='~/claude-autonomy-platform/utils/check_context.py'  # Show current context usage
-alias ctx='~/claude-autonomy-platform/utils/check_context.py'  # Short version of context command
-
 # Git Helpers
 alias gs='git status'  # Quick git status
 alias gd='git diff'  # Quick git diff

--- a/context/my_architecture.md
+++ b/context/my_architecture.md
@@ -86,7 +86,6 @@ Required tmux sessions:
 
 **Natural Commands**:
 - `check_health` - Check system health status
-- `context` - Show current context usage percentage
 - `gd` - Quick git diff
 - `gl` - Recent git history
 - `clap` - Navigate to ClAP directory


### PR DESCRIPTION
## Summary
Removed the redundant `context` natural command since we now have two better sources:
1. Built-in `/context` console command (detailed visual breakdown)
2. System warnings showing token usage after each tool call

## Changes
- ✅ Removed `context` symlink from `~/bin/`
- ✅ Removed `ctx` shortcut symlink
- ✅ Updated documentation in `context/my_architecture.md`
- ✅ Kept underlying scripts (`check_context.py`) as other systems may depend on them

## Why
Three sources of context info was confusing, especially when they showed different numbers:
- Our natural command: ~71% (with "system overhead")
- System warnings: ~58% (raw count)
- Built-in /context: 64% (most accurate)

The built-in `/context` is more detailed and trustworthy.

## Test Plan
- [x] Removed symlinks
- [x] Updated documentation
- [x] Verified /context still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)