### PR TITLE
fix: Session swap export command bugs

### DIFF
--- a/utils/session_swap.sh
+++ b/utils/session_swap.sh
@@ -64,8 +64,7 @@ cd "$CLAP_DIR" || exit
 echo "[SESSION_SWAP] Exporting current conversation..."
 
 # First ensure Claude is in the correct directory using shell command
-send_to_claude "!"
-send_to_claude "cd $CLAP_DIR"
+send_to_claude "! cd $CLAP_DIR"
 
 # Wait for shell command to complete
 sleep 2
@@ -77,13 +76,8 @@ full_path="$CLAP_DIR/$export_path"
 echo "[SESSION_SWAP] Starting export..."
 send_to_claude "/export $export_path"
 
-# Wait for dialog and select option 2 (no enters before or after)
-sleep 3
-send_to_claude "2" "true" "true"
-
-# Wait longer for export to process before confirmation
-sleep 3
-send_to_claude ""
+# Wait for export to complete (no confirmation dialog anymore)
+sleep 5
 
 # Give more time for file to be written after confirmation
 sleep 5


### PR DESCRIPTION
Fixes two critical bugs in session swap that caused export to fail:

1. **Split shell command** - Was sending `!` and `cd` as separate commands instead of combined `! cd` shell command. This caused export to save in wrong directory when cd wasn't properly executed.

2. **Obsolete confirmation dialog** - Was sending "2" to select option in /export confirmation dialog that no longer exists in Claude Code.

**Changes:**
- Combine "!" and "cd" into single shell command: `send_to_claude "! cd $CLAP_DIR"`
- Remove obsolete "2" response and empty "" send
- Simplify to just wait 5s for export to complete

**Impact:**
- Prevents session swap failures where export saves to wrong directory
- Fixes the bug that caused timeline confusion on 2026-01-27 ~16:30

**Testing:**
- Verified fix resolves the export directory issue
- Confirmed simplified export flow works without confirmation dialog

Discovered and fixed: 2026-01-27