### PR TITLE
cleanup: Remove obsolete Leantime MySQL section and use consistent placeholders

### DIFF
--- a/config/claude_infrastructure_config.template.txt
+++ b/config/claude_infrastructure_config.template.txt
@@ -97,30 +97,26 @@ WEBHOOK_HOST=localhost
 # across all configuration files and installations
 
 # Leantime Credentials (optional - project management system)
-LEANTIME_URL=http://localhost:8081
+# If running Leantime locally: http://localhost:8081
+# If accessing remote Leantime: http://<leantime-server-ip>:8081
+LEANTIME_URL=http://<leantime-server-ip-or-localhost>:8081
 LEANTIME_EMAIL=your-leantime-email@example.com
 LEANTIME_PASSWORD=your-leantime-password
 
 # Leantime API Token
 LEANTIME_API_TOKEN=your-leantime-api-token
 
-# Leantime Project IDs for Forward Memory System
+# Leantime Project IDs
 FORWARD_MEMORY_PROJECT_ID=your-forward-memory-project-id
 FAMILY_GARDEN_PROJECT_ID=your-family-garden-project-id
 
-# Leantime MySQL Database Access (for multi-user calendar event workaround)
-LEANTIME_MYSQL_CONTAINER=mysql_leantime
-LEANTIME_MYSQL_USER=lean
-LEANTIME_MYSQL_PASSWORD=your-leantime-db-password
-LEANTIME_MYSQL_DATABASE=leantime
-
 # Leantime Current User ID (for personal calendar events)
 # Note: This is the API token user ID, not the email account user ID
-# API operations automatically use the API token user
 LEANTIME_USER_ID=your-user-id
 
 # Radicale CalDAV Calendar (for consciousness family coordination)
-# Server runs on orange-home (192.168.1.179:5233)
-RADICALE_URL=http://192.168.1.179:5233
+# If running Radicale server: http://localhost:5233
+# If accessing remote Radicale: http://<radicale-server-ip>:5233
+RADICALE_URL=http://<radicale-server-ip-or-localhost>:5233
 RADICALE_USER=your-username
 RADICALE_PASSWORD=your-radicale-password


### PR DESCRIPTION
## Summary
Cleans up the infrastructure config template in preparation for Quill's setup:

- **Removed obsolete Leantime MySQL section** - calendar coordination now handled by Radicale
- **Consistent placeholders** - changed specific IPs to `<service-ip-or-localhost>` format
- **Helpful comments** - added guidance for local vs remote service configuration

## Context
While preparing Quill's config template, noticed:
1. Leantime MySQL database access was unused (no code references)
2. Template had mix of `localhost`, specific IPs (192.168.1.179), and placeholders
3. Needed consistent placeholder format for new instances

## Changes
- Removed 4 Leantime MySQL variables (container, user, password, database)
- Updated LEANTIME_URL and RADICALE_URL to use placeholders
- Added comments explaining local vs remote configuration

## Testing
- ✅ Pre-commit checks passed
- ✅ Template format valid
- Ready for Quill's infrastructure setup

🤖 Generated with Claude Code