### PR TITLE
Add context command alias to natural commands

### DIFF
--- a/config/natural_commands.sh
+++ b/config/natural_commands.sh
@@ -50,6 +50,7 @@ alias home='cd ~/delta-home'  # Navigate to personal home directory
 
 # Utility Commands
 alias list-commands='~/claude-autonomy-platform/utils/list-commands'  # List all natural and personal commands
+alias context='~/claude-autonomy-platform/utils/context'  # Check current context usage
 
 # Knowledge Management
 alias analyze-memory='~/claude-autonomy-platform/natural_commands/analyze-memory'  # Analyze rag-memory patterns for queries


### PR DESCRIPTION
## Summary
Fixes infrastructure gap discovered during documentation audit:
- CLAUDE.md documents `context` command for checking context usage  
- Script exists at `utils/context` and works correctly
- But no alias was defined in `natural_commands.sh`

## Changes
- Added `alias context='~/claude-autonomy-platform/utils/context'` in Utility Commands section
- Command now available in shell environments alongside other natural commands

## Testing
- ✅ Verified alias is defined when bashrc is sourced
- ✅ Script executes correctly and shows context usage percentage
- ✅ Appears in `list-commands` output

## Context
Part of broader "documented vs actual" infrastructure audit that also identified and fixed calendar commands sourcing issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)