### PR TITLE
Add context command alias to natural commands

### DIFF
--- a/config/natural_commands.sh
+++ b/config/natural_commands.sh
@@ -50,6 +50,7 @@ alias home='cd ~/delta-home'  # Navigate to personal home directory
 
 # Utility Commands
 alias list-commands='~/claude-autonomy-platform/utils/list-commands'  # List all natural and personal commands
+alias context='~/claude-autonomy-platform/utils/context'  # Check current context usage
 
 # Knowledge Management
 alias analyze-memory='~/claude-autonomy-platform/natural_commands/analyze-memory'  # Analyze rag-memory patterns for queries


### PR DESCRIPTION
## Summary
Adds the `context` command alias to natural_commands.sh, completing infrastructure audit work.

## Changes
- Added `context` alias pointing to `utils/context` script
- Command was documented in CLAUDE.md but not integrated into natural commands
- Found during "documented vs actual" infrastructure audit

## Testing
- Verified `context` command now works from bash
- Checked command displays context usage correctly

🔧 Infrastructure gap fixed from audit work!