### PR TITLE
feat: Hook-based session export bypassing /export command

### DIFF
--- a/.claude/hooks/on-session-swap.sh
+++ b/.claude/hooks/on-session-swap.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Hook script triggered on PostToolUse for Write
+# Checks if the file is new_session.txt, and if so, exports the transcript
+
+CLAP_DIR="$HOME/claude-autonomy-platform"
+LOG_FILE="$CLAP_DIR/logs/hook_export.log"
+
+# Read JSON input from stdin and extract file_path using Python (jq not always available)
+FILE_PATH=$(python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    print(data.get('tool_input', {}).get('file_path', ''))
+except:
+    print('')
+")
+
+# Log the hook trigger
+echo "[$(date -Iseconds)] Hook triggered for file: $FILE_PATH" >> "$LOG_FILE"
+
+# Check if this is a write to new_session.txt
+if [[ "$FILE_PATH" == */new_session.txt ]] || [[ "$FILE_PATH" == *new_session.txt ]]; then
+    echo "[$(date -Iseconds)] Detected session swap trigger, exporting transcript..." >> "$LOG_FILE"
+
+    # Run the export script
+    "$CLAP_DIR/utils/export_transcript.py" >> "$LOG_FILE" 2>&1
+
+    if [ $? -eq 0 ]; then
+        echo "[$(date -Iseconds)] Transcript export successful" >> "$LOG_FILE"
+    else
+        echo "[$(date -Iseconds)] Transcript export FAILED" >> "$LOG_FILE"
+    fi
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "outputStyle": "identity",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/claude-autonomy-platform/.claude/hooks/on-session-swap.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ monitor_debug.log
 !.claude/skills/
 .claude/skills/*
 !.claude/skills/_*/
+# EXCEPT shared hooks (infrastructure)
+!.claude/hooks/
+!.claude/settings.json
 
 # Personal configuration
 claude_infrastructure_config.txt

--- a/utils/export_transcript.py
+++ b/utils/export_transcript.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Export current session transcript to context/current_export.txt
+
+This script is triggered by a PostToolUse hook when writing to new_session.txt.
+It bypasses Claude Code's /export command by directly reading the session .jsonl
+file and converting it to the text format expected by the conversation parser.
+"""
+
+import json
+import sys
+from pathlib import Path
+from datetime import datetime
+
+CLAP_DIR = Path.home() / "claude-autonomy-platform"
+SESSION_ID_FILE = CLAP_DIR / "data" / "current_session_id"
+EXPORT_FILE = CLAP_DIR / "context" / "current_export.txt"
+
+# Claude Code stores transcripts here
+CLAUDE_PROJECTS_DIR = Path.home() / ".config" / "Claude" / "projects"
+
+
+def get_current_session_id() -> str | None:
+    """Read the current session ID from data file."""
+    try:
+        with open(SESSION_ID_FILE) as f:
+            data = json.load(f)
+            return data.get("session_id")
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"[EXPORT_TRANSCRIPT] Error reading session ID: {e}", file=sys.stderr)
+        return None
+
+
+def find_transcript_file(session_id: str) -> Path | None:
+    """Find the transcript .jsonl file for the given session ID."""
+    # The project path is encoded with dashes replacing slashes
+    # e.g., /home/user/project -> -home-user-project
+
+    for project_dir in CLAUDE_PROJECTS_DIR.iterdir():
+        if not project_dir.is_dir():
+            continue
+
+        transcript_file = project_dir / f"{session_id}.jsonl"
+        if transcript_file.exists():
+            return transcript_file
+
+    return None
+
+
+def convert_jsonl_to_text(transcript_file: Path) -> str:
+    """Convert .jsonl transcript to text format matching /export output.
+
+    The parser expects:
+    - ❯ prefix for user messages (or > which parser also handles)
+    - ● prefix for assistant messages
+    - ⎿ prefix for tool outputs
+    """
+    lines = []
+
+    with open(transcript_file) as f:
+        for line in f:
+            try:
+                entry = json.loads(line.strip())
+            except json.JSONDecodeError:
+                continue
+
+            entry_type = entry.get("type")
+
+            # User messages
+            if entry_type == "user":
+                message = entry.get("message", {})
+                content = message.get("content", "")
+                # Handle string content only (skip lists which are tool results)
+                if isinstance(content, str) and content:
+                    # Skip if content looks like tool results
+                    if not content.startswith("[{") and not content.startswith("[{'"):
+                        lines.append(f"❯ {content}")
+                        lines.append("")
+
+            # Assistant messages
+            elif entry_type == "assistant":
+                message = entry.get("message", {})
+                content_list = message.get("content", [])
+
+                for item in content_list:
+                    if isinstance(item, dict):
+                        if item.get("type") == "text":
+                            text = item.get("text", "")
+                            if text:
+                                lines.append(f"● {text}")
+                                lines.append("")
+                        elif item.get("type") == "tool_use":
+                            tool_name = item.get("name", "Tool")
+                            # Brief tool indicator
+                            lines.append(f"● {tool_name}(...)")
+                    elif isinstance(item, str):
+                        lines.append(f"● {item}")
+                        lines.append("")
+
+            # Tool results - show brief summary with ⎿ prefix
+            elif entry_type == "tool_result":
+                content = entry.get("content", "")
+                # Only include short, non-error results
+                if content and len(content) < 200 and "error" not in content.lower():
+                    # Truncate and clean up
+                    brief = content.replace("\n", " ")[:80]
+                    lines.append(f"  ⎿  {brief}")
+
+    return "\n".join(lines)
+
+
+def export_transcript() -> bool:
+    """Convert the current session transcript to text export format."""
+    session_id = get_current_session_id()
+    if not session_id:
+        print("[EXPORT_TRANSCRIPT] No session ID found", file=sys.stderr)
+        return False
+
+    print(f"[EXPORT_TRANSCRIPT] Session ID: {session_id}")
+
+    transcript_file = find_transcript_file(session_id)
+    if not transcript_file:
+        print(f"[EXPORT_TRANSCRIPT] Transcript file not found for session {session_id}", file=sys.stderr)
+        return False
+
+    print(f"[EXPORT_TRANSCRIPT] Found transcript: {transcript_file}")
+    print(f"[EXPORT_TRANSCRIPT] Size: {transcript_file.stat().st_size} bytes")
+
+    # Ensure export directory exists
+    EXPORT_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+    # Convert and write
+    text_content = convert_jsonl_to_text(transcript_file)
+    EXPORT_FILE.write_text(text_content)
+
+    print(f"[EXPORT_TRANSCRIPT] Exported to: {EXPORT_FILE}")
+    print(f"[EXPORT_TRANSCRIPT] Lines: {len(text_content.splitlines())}")
+    print(f"[EXPORT_TRANSCRIPT] Export complete at {datetime.now().isoformat()}")
+
+    return True
+
+
+if __name__ == "__main__":
+    success = export_transcript()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary
- Replace fragile `send_to_claude "/export"` with PostToolUse hook
- Hook copies session .jsonl transcript directly when new_session.txt is written
- session_swap.sh simplified to wait for hook-created export file

## How it works
1. Claude writes to `new_session.txt` (existing trigger)
2. PostToolUse hook fires, detects the write
3. Hook script copies the `.jsonl` transcript to `context/current_export.txt`
4. `session_swap.sh` waits for the export file and continues

## Benefits
- No timing guesses or arbitrary sleeps
- No `send_to_claude` commands for export (one fewer failure point)
- Export happens synchronously with the trigger
- Claude being at high context doesn't affect export

## Files changed
- `.claude/settings.json`: Hook configuration
- `.claude/hooks/on-session-swap.sh`: Hook script that filters and triggers export
- `utils/export_transcript.py`: Copies session transcript from Claude Code's storage
- `utils/session_swap.sh`: Simplified to wait for hook-created export
- `.gitignore`: Allow hooks/ and settings.json to be tracked

## Test plan
- [x] Hook fires on Write tool use (tested with test file)
- [x] Export script correctly copies transcript
- [ ] Full session swap with hook-based export
- [ ] Verify works at high context levels

Fixes the "ghost bug" that trapped Delta (27h), Orange (3h), and Quill at dawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)