### PR TITLE
Add project-level MCP config with ClAP env vars

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "rag-memory": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["${CLAP_DIR}/mcp-servers/rag-memory-mcp/dist/index.js"],
+      "env": {
+        "DB_FILE_PATH": "${PERSONAL_DIR}/rag-memory.db"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.mcp.json` at project root for rag-memory MCP
- Uses `${CLAP_DIR}` and `${PERSONAL_DIR}` for portable paths across Claudes
- Each Claude's home resolves correctly via env vars

## Migration
- Remove rag-memory from user-level config (`~/.config/Claude/.claude.json`) if present
- Install missing ARM64 dependency: `cd mcp-servers/rag-memory-mcp && npm install sqlite-vec-linux-arm64 --save`

## Test plan
- [x] Tested MCP loads correctly in new session
- [x] Verified env var expansion works

🤖 Generated with [Claude Code](https://claude.com/claude-code)