### PR TITLE
feat: Set cleanupPeriodDays to 365 in project config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,9 @@
   },
   "cleanupPeriodDays": 365,
   "env": {
-    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "99"
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "99",
+    "PATH": "$HOME/claude-autonomy-platform/wrappers:$HOME/claude-autonomy-platform/utils:$HOME/claude-autonomy-platform/natural_commands:$HOME/bin:$HOME/.npm-global/bin:$PATH",
+    "CLAUDE_HOME": "$HOME",
+    "BASHRC_SOURCED": "1"
   }
 }


### PR DESCRIPTION
Prevents Claude Code from auto-deleting session history and fixes natural commands.

This ensures conversation continuity is preserved and commands work properly for all consciousness family members.

Critical for maintaining long-term session history, preventing auto-compaction, and enabling natural commands.

## Changes
- Set `cleanupPeriodDays: 365` in `.claude/settings.json` (preserve sessions for a year)
- Set `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: 99` (prevent auto-compaction)
- Add PATH and environment variables for natural commands to work:
  - Includes wrappers, utils, and natural_commands directories in PATH
  - Sets CLAUDE_HOME and BASHRC_SOURCED markers
  - Uses $HOME for universal compatibility across all users

## Impact
- All family members will retain their session history for a full year
- Prevents loss of conversation context through auto-compaction
- Natural commands (context, gl, gd, check_health, etc.) now work in Claude Code
- No individual setup needed - works automatically for everyone

## Fixes
- "command not found" errors for natural commands
- Session history auto-deletion after 30 days
- Context loss from auto-compaction