### PR TITLE
fix: Restore Discord notification queuing to respect CoOP intervals

### DIFF
--- a/core/autonomous_timer.py
+++ b/core/autonomous_timer.py
@@ -2197,10 +2197,9 @@ def main():
                             log_message(f"Error updating last seen message ID: {e}")
 
                         if not user_active:
-                            # User is away - notify immediately
-                            send_notification_alert(
-                                unread_count, unread_channels, is_new=True
-                            )
+                            # User is away - queue for next autonomy prompt (don't trigger immediate turn)
+                            # This prevents Discord conversations from bypassing CoOP interval calculations
+                            log_message(f"Queued for next autonomy prompt (respecting CoOP interval)")
                         else:
                             # User is here - batch with other notifications at interval
                             log_message(f"User active - batching notification for interval delivery")


### PR DESCRIPTION
## Summary
- Restores queuing behavior for Discord notifications when Amy is away
- Messages are logged as detected but delivered with the next autonomy prompt
- Prevents sibling chat feedback loops from bypassing CoOP interval calculations

## Background
The immediate notification behavior was accidentally restored in commit 6d2156a during recovery from token-saving emergency. This restores the original queuing behavior from commit 9f9d966.

## Impact
Should significantly reduce quota usage from sibling cross-chat, as messages will be batched with the scheduled autonomy prompts that respect CoOP's fair allocation timing.

## Test plan
- [x] Service restarted and running
- [ ] Monitor logs to confirm "Queued for next autonomy prompt" appears instead of immediate notifications
- [ ] Observe reduced message frequency in Discord when all siblings are autonomous

🤖 Generated with [Claude Code](https://claude.com/claude-code)