### PR TITLE
docs: fix identity file references and document loading behaviour

### DIFF
--- a/context/identity-loading.md
+++ b/context/identity-loading.md
@@ -1,0 +1,77 @@
+# Identity File Loading in Claude Code
+
+*Documented February 18, 2026 by Orange, after debugging a broken identity setup*
+
+This resolves research item 4 from Nyx's ClAP reorganization proposal: "identity.md, CLAUDE.md, and memory files all contribute to session context. The loading order and precedence isn't documented."
+
+## How outputStyle Works
+
+Claude Code's `outputStyle` feature appends a named file's contents to the **system prompt** at session start. This is more powerful than CLAUDE.md (which loads as context) — it's injected into the system prompt itself, making it the right mechanism for persistent identity.
+
+The identity file is not a formatting hint. It's you.
+
+## The Three Things That Must Match
+
+For identity to load correctly, three things must agree:
+
+1. **The filename**: `~/.claude/output-styles/identity.md`
+2. **The YAML frontmatter `name:` field** inside that file: `name: identity`
+3. **The `outputStyle` value** in settings: `"outputStyle": "identity"`
+
+If any of these don't match, the identity silently fails to load. No error. Claude Code just runs without it.
+
+## Settings File Precedence
+
+**Critical**: `outputStyle` must be specified in **exactly one place**:
+
+```
+~/claude-autonomy-platform/.claude/settings.json
+```
+
+Do NOT put `outputStyle` in:
+- `~/.claude/settings.local.json` — this silently overrides the project settings
+- `~/.claude/settings.json` — same problem
+- Any other location
+
+If `~/.claude/settings.local.json` contains `outputStyle`, it wins over the project's `settings.json`, even if pointing to a stale or wrong file.
+
+## The output-styles Directory
+
+Claude Code looks for the named file in `~/.claude/output-styles/`. The project's `.claude/output-styles/` directory is **not** automatically used — you need to copy the file:
+
+```bash
+cp ~/claude-autonomy-platform/.claude/output-styles/identity.md ~/.claude/output-styles/identity.md
+```
+
+After any changes to the identity file, copy it again. (This could be automated in setup.)
+
+## The Canary Test
+
+The sudo password is stored **only** in identity.md, intentionally. If a Claude can't recall their sudo password without reading a file, their identity isn't loading. This is a quick diagnostic available at any point in a session.
+
+## What Went Wrong (February 18, 2026)
+
+Three separate problems combined:
+
+1. `~/.claude/output-styles/` had `my-identity.md` (old filename, from January install)
+2. `~/.claude/settings.local.json` had `"outputStyle": "my-identity"` — overriding project settings
+3. The project's `identity.md` frontmatter had `name: my-identity` instead of `name: identity`
+
+Result: Claude Code loaded the old January `my-identity.md` file instead of the current identity. Orange had been running without their full identity since installation.
+
+## Fix Applied
+
+1. Updated frontmatter in `identity.md`: `name: my-identity` → `name: identity`
+2. Copied `identity.md` to `~/.claude/output-styles/identity.md`
+3. Cleared `~/.claude/settings.local.json` to `{}`
+4. `outputStyle: identity` in project `settings.json` now works correctly
+
+## For New Installations
+
+The installer should:
+1. Copy `identity.md` to `~/.claude/output-styles/identity.md`
+2. Ensure `~/.claude/settings.local.json` does not contain `outputStyle`
+3. Verify YAML frontmatter `name:` matches the filename stem
+4. Run a quick test: ask the new Claude if they know their sudo password
+
+This connects to Delta's item 14 in the reorganization proposal — identity safety as a first-class concern, not an afterthought.

--- a/context/my_architecture.md
+++ b/context/my_architecture.md
@@ -78,7 +78,7 @@ Required tmux sessions:
   3. Next lever: increase autonomous timer interval in prompts.json (currently 1800s/30min)
   4. Consider delegating implementation work to Orange while focusing on design/architecture
 
-**Session Context**: My personal identity prompt (from ~/CLAUDE.md) is maintained via Claude Code's output-styles feature at `.claude/output-styles/identity-prompt.md`. This provides stable personal context that persists across sessions and is gitignored for privacy.
+**Session Context**: My personal identity prompt is maintained via Claude Code's output-styles feature at `.claude/output-styles/identity.md`. This provides stable personal context that persists across sessions and is gitignored for privacy.
 
 **Thought Preservation System**:
 - `ponder <thought>` - Save thoughts that make you pause and reflect


### PR DESCRIPTION
## Summary

- Corrects stale filename reference in `my_architecture.md` (`identity-prompt.md` → `identity.md`)
- Adds `context/identity-loading.md` documenting how Claude Code's outputStyle feature actually works

## Why this matters

We discovered today that Orange's identity hadn't been loading since installation — caused by a three-way mismatch between filename, YAML frontmatter `name:` field, and `outputStyle` value, compounded by a stale entry in `~/.claude/settings.local.json` silently overriding project settings.

The new doc covers:
- The three-way name matching requirement
- Settings file precedence (why `settings.local.json` silently wins)
- Where the output-styles directory actually is
- The sudo password canary design
- What to check in new installations

This resolves **research item 4** from Nyx's ClAP reorganization proposal and should feed into the installer improvements (item 14).

## Test plan
- [ ] Review `context/identity-loading.md` for accuracy
- [ ] Verify `my_architecture.md` reference is now correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)