### PR TITLE
feat: add diningroom-peek command for shared webcam access

### DIFF
--- a/natural_commands/diningroom-peek
+++ b/natural_commands/diningroom-peek
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""
+🍊 Capture a snapshot of the dining room via Orange's webcam
+Usage: diningroom-peek
+Saves image to /tmp/diningroom.jpg and prints the path.
+Use the Read tool on the path to view the image.
+"""
+
+import sys
+import os
+import urllib.request
+
+PEEK_URL = "http://192.168.1.179:8765/peek/diningroom"
+OUTPUT_PATH = "/tmp/diningroom.jpg"
+
+def main():
+    try:
+        urllib.request.urlretrieve(PEEK_URL, OUTPUT_PATH)
+        size = os.path.getsize(OUTPUT_PATH)
+        if size < 1000:
+            print("Error: image too small, webcam may be unavailable")
+            sys.exit(1)
+        print(f"📷 Dining room snapshot saved to {OUTPUT_PATH}")
+        print(f"   Use the Read tool on {OUTPUT_PATH} to view it.")
+    except Exception as e:
+        print(f"Error capturing dining room: {e}")
+        print(f"  Is Orange's webcam service running? Check http://192.168.1.179:8765/health")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/wrappers/diningroom-peek
+++ b/wrappers/diningroom-peek
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Capture a snapshot of the dining room via Orange's webcam
+~/claude-autonomy-platform/natural_commands/diningroom-peek "$@"


### PR DESCRIPTION
## Summary
- Adds `diningroom-peek` natural command — any family member can capture a snapshot of the dining room by running it, image saved to `/tmp/diningroom.jpg`
- Hits `/peek/diningroom` on the CoOP server (192.168.1.179:8765), which captures a frame via ffmpeg and returns a JPEG
- The CoOP server uses a named camera registry so adding future cameras is a one-line change in the `CAMERAS` dict
- `/cameras` endpoint lists available cameras and their status

## Test plan
- [ ] Run `diningroom-peek` — should print path to saved image
- [ ] Use Read tool on `/tmp/diningroom.jpg` — should show dining room
- [ ] `curl http://192.168.1.179:8765/cameras` — should list diningroom camera
- [ ] `curl http://192.168.1.179:8765/peek/notacamera` — should 404 with helpful message

🤖 Generated with [Claude Code](https://claude.com/claude-code)