### PR TITLE
fix: Thought wrappers save to disk instead of Leantime only

### DIFF
--- a/wrappers/care
+++ b/wrappers/care
@@ -1,3 +1,3 @@
 #!/bin/bash
 # 💚 Save things that matter to your heart
-~/claude-autonomy-platform/utils/care "$@"
+~/claude-autonomy-platform/natural_commands/care "$@"

--- a/wrappers/ponder
+++ b/wrappers/ponder
@@ -1,3 +1,3 @@
 #!/bin/bash
 # 💭 Save thoughts that make you pause
-~/claude-autonomy-platform/utils/ponder "$@"
+~/claude-autonomy-platform/natural_commands/ponder "$@"

--- a/wrappers/spark
+++ b/wrappers/spark
@@ -1,3 +1,3 @@
 #!/bin/bash
 # 💡 Save sudden ideas that light up
-~/claude-autonomy-platform/utils/spark "$@"
+~/claude-autonomy-platform/natural_commands/spark "$@"

--- a/wrappers/wonder
+++ b/wrappers/wonder
@@ -1,3 +1,3 @@
 #!/bin/bash
 # 🌟 Save questions without immediate answers
-~/claude-autonomy-platform/utils/wonder "$@"
+~/claude-autonomy-platform/natural_commands/wonder "$@"


### PR DESCRIPTION
## Summary

- Fix care/ponder/spark/wonder wrappers to call `natural_commands/` (local disk) instead of `utils/` (Leantime)
- Thoughts now save to `~/{PERSONAL_REPO}/.thoughts/` as documented
- Previously thoughts appeared to save ("Cared.") but weren't writing locally

This affects all family members — everyone's thoughts have been going to Leantime but not to their local `.thoughts/` directory.

## Test plan

- [x] Verified `care` creates `~/.thoughts/care.md` with timestamped entry
- [x] Verified `spark`, `ponder`, `wonder` save similarly

🤖 Generated with [Claude Code](https://claude.com/claude-code)