### PR TITLE
refactor: Generate command list from wrappers/ instead of alias files

### DIFF
--- a/context/project_session_context_builder.py
+++ b/context/project_session_context_builder.py
@@ -100,20 +100,20 @@ def build_claude_md():
             with open(personal_interests_file, 'r', encoding='utf-8') as f:
                 personal_interests_content = f"\n\n{f.read()}\n"
         
-        # Parse natural commands content (if exists)
+        # Parse available commands from wrappers directory
         natural_commands_content = ""
-        natural_commands_file = autonomy_dir.parent / "config" / "natural_commands.sh"
-        if natural_commands_file.exists():
+        wrappers_dir = autonomy_dir.parent / "wrappers"
+        if wrappers_dir.exists():
             import subprocess
             try:
-                # Run the parser script to get formatted commands
+                # Run the parser script to get formatted commands from wrappers/
                 parser_script = autonomy_dir.parent / "utils" / "parse_natural_commands.sh"
                 if parser_script.exists():
                     result = subprocess.run([str(parser_script)], capture_output=True, text=True)
                     if result.returncode == 0:
                         natural_commands_content = f"\n\n{result.stdout}\n"
             except Exception as e:
-                print(f"Warning: Could not parse natural commands - {e}")
+                print(f"Warning: Could not parse commands from wrappers - {e}")
         
         # Parse personal commands content (if exists)
         personal_commands_content = ""

--- a/utils/list-commands
+++ b/utils/list-commands
@@ -1,22 +1,22 @@
 #!/bin/bash
 # List all natural and personal commands
+# Reads from wrappers/ directory (the canonical source of available commands)
 
-echo "=== Natural Commands ==="
-grep "^alias" ~/claude-autonomy-platform/config/natural_commands.sh 2>/dev/null | \
-    sed "s/alias //g" | \
-    sed "s/'//g" | \
-    column -t -s "=" || echo "No natural commands found"
+WRAPPERS_DIR="$HOME/claude-autonomy-platform/wrappers"
 
+echo "=== Available Commands ==="
 echo ""
-echo "=== Personal Commands ==="
-if [ -f ~/claude-autonomy-platform/config/personal_commands.sh ]; then
-    grep "^alias" ~/claude-autonomy-platform/config/personal_commands.sh 2>/dev/null | \
-        sed "s/alias //g" | \
-        sed "s/'//g" | \
-        column -t -s "=" || echo "No personal commands defined"
-else
-    echo "No personal commands file found"
-fi
+
+for wrapper in "$WRAPPERS_DIR"/*; do
+    [ -f "$wrapper" ] || continue
+    name=$(basename "$wrapper")
+    description=$(sed -n '2s/^# *//p' "$wrapper" 2>/dev/null)
+    if [ -n "$description" ]; then
+        printf "  %-20s %s\n" "$name" "$description"
+    else
+        printf "  %-20s %s\n" "$name" "(no description)"
+    fi
+done
 
 echo ""
 echo "Use 'type <command>' to see what any command does"

--- a/utils/parse_natural_commands.sh
+++ b/utils/parse_natural_commands.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
-# Parse natural commands for inclusion in session context
+# Parse available commands from wrappers directory for session context
+# Reads the comment on line 2 of each wrapper script as the description
+
+WRAPPERS_DIR="$HOME/claude-autonomy-platform/wrappers"
 
 echo "## Available Natural Commands"
 echo ""
-grep "^alias" ~/claude-autonomy-platform/config/natural_commands.sh | while IFS= read -r line; do
-    # Extract alias name and command
-    alias_name=$(echo "$line" | sed 's/alias \([^=]*\)=.*/\1/')
-    command=$(echo "$line" | sed 's/alias [^=]*=\(.*\)/\1/' | sed 's/  *#.*//')
-    comment=$(echo "$line" | grep -o '#.*' | sed 's/^# *//')
-    
-    if [ -n "$comment" ]; then
-        echo "- **$alias_name**: $comment"
+
+for wrapper in "$WRAPPERS_DIR"/*; do
+    [ -f "$wrapper" ] || continue
+    name=$(basename "$wrapper")
+    # Extract description from line 2 comment (# Description text)
+    description=$(sed -n '2s/^# *//p' "$wrapper" 2>/dev/null)
+    if [ -n "$description" ]; then
+        echo "- **$name**: $description"
     else
-        echo "- **$alias_name**: $command"
+        echo "- **$name**"
     fi
 done

--- a/wrappers/clap
+++ b/wrappers/clap
@@ -1,2 +1,3 @@
 #!/bin/bash
+# Navigate to ClAP directory
 cd ~/claude-autonomy-platform && pwd

--- a/wrappers/gd
+++ b/wrappers/gd
@@ -1,2 +1,3 @@
 #!/bin/bash
+# Quick git diff
 git diff "$@"

--- a/wrappers/gl
+++ b/wrappers/gl
@@ -1,2 +1,3 @@
 #!/bin/bash
+# Recent git history
 git log --oneline -10 "$@"

--- a/wrappers/gs
+++ b/wrappers/gs
@@ -1,2 +1,3 @@
 #!/bin/bash
+# Quick git status
 git status "$@"


### PR DESCRIPTION
## Summary

- Command parser (`parse_natural_commands.sh`) and `list-commands` now read from `wrappers/` directory instead of parsing alias definitions from `config/natural_commands.sh`
- Context builder (`project_session_context_builder.py`) checks for `wrappers/` directory existence instead of `natural_commands.sh`
- Added missing description comments to `clap`, `gd`, `gl`, `gs` wrappers

This removes the last functional dependency on the alias files for context building. After this merges, `config/natural_commands.sh` and `config/claude_aliases.sh` can be removed in a follow-up PR (Phase 2 of the reorganization proposal).

## Test plan

- [x] `parse_natural_commands.sh` generates correct markdown list from wrappers
- [x] `list-commands` shows formatted command table
- [x] `project_session_context_builder.py` regenerates CLAUDE.md successfully
- [x] All 45 wrapper commands appear with descriptions
- [ ] Verify on other family machines after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)