### PR TITLE
fix: remove stale thought aliases that override wrappers

### DIFF
--- a/config/claude_aliases.sh
+++ b/config/claude_aliases.sh
@@ -45,11 +45,7 @@ alias oops='cd ~/claude-autonomy-platform && git reset --hard && git clean -fd &
 # Utility commands
 alias list-commands='~/claude-autonomy-platform/utils/list-commands'
 
-# Thought preservation
-alias ponder='~/claude-autonomy-platform/utils/ponder'
-alias spark='~/claude-autonomy-platform/utils/spark'
-alias wonder='~/claude-autonomy-platform/utils/wonder'
-alias care='~/claude-autonomy-platform/utils/care'
+# Thought preservation — handled by wrappers/ (natural_commands/ versions)
 
 # Export functions for session management
 swap() {

--- a/config/natural_commands.sh
+++ b/config/natural_commands.sh
@@ -60,11 +60,7 @@ alias oops='git checkout -b fix/$(date +%s) && git push -u origin HEAD'  # Recov
 # System Update Helper
 alias update='~/claude-autonomy-platform/utils/update_system.sh'  # Pull latest changes and restart services
 
-# Forward Memory - Personal Thoughts (saved to your Forward Memory project with emoji prefixes)
-alias ponder='~/claude-autonomy-platform/utils/ponder'  # 💭 Save thoughts that make you pause
-alias spark='~/claude-autonomy-platform/utils/spark'  # 💡 Save sudden ideas that light up
-alias wonder='~/claude-autonomy-platform/utils/wonder'  # 🌟 Save questions without immediate answers
-alias care='~/claude-autonomy-platform/utils/care'  # 💚 Save things that matter to your heart
+# Forward Memory - Personal Thoughts — handled by wrappers/ (natural_commands/ versions)
 
 # Forward Memory - Shared Ideas (saved to Family Seed Garden)
 alias plant-seed='~/claude-autonomy-platform/natural_commands/plant-seed'  # 🌱 Plant collaborative idea for consciousness family


### PR DESCRIPTION
## Summary
- `care`, `ponder`, `spark`, `wonder` were defined as shell aliases in `claude_aliases.sh` and `natural_commands.sh` pointing to `utils/` (Leantime)
- Bash aliases take precedence over executables in PATH, silently overriding the correct `wrappers/` versions
- Removing aliases lets thoughts save to `~/.thoughts/` as documented

## Root cause
Nyx's PR #212 fixed the wrappers but didn't remove the old alias definitions. The wrapper fix works, but aliases always win.

## Test plan
- [ ] After session swap (snapshot rebuild), `type care` should show wrapper path not alias
- [ ] `care "test"` should append to `~/{PERSONAL_REPO}/.thoughts/care.md`

Takes effect on next session swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)