### PR TITLE
fix: gut alias files and add calendar wrappers

### DIFF
--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -16,10 +16,10 @@
 - **`prompts.json`** — Templates for autonomous timer messages, context warnings, session swap notifications. Also contains context escalation thresholds (70%/80%/95%) and swap keywords.
 - **`context_hats_config.json`** — Maps session keywords (AUTONOMY, BUSINESS, etc.) to context documents loaded during session swaps.
 
-### Commands (scheduled for removal)
-- **`natural_commands.sh`** — Shell functions for natural language commands. Redundant with `wrappers/` directory, which is the actual working mechanism in Claude Code's shell.
-- **`claude_aliases.sh`** — Older alias definitions. Same redundancy problem. Both files are slated for removal in Phase 2 of the reorganization.
-- **`shared_functions.sh`** — Utility functions used by the alias/command files.
+### Commands (deprecated stubs)
+- **`natural_commands.sh`** — Empty stub. All commands moved to `wrappers/`. Kept so existing `source` statements don't break.
+- **`claude_aliases.sh`** — Empty stub. Same reason. Both can be fully deleted once all references are cleaned up.
+- **`shared_functions.sh`** — Utility functions used by the old alias/command files.
 
 ### Initialization
 - **`claude_init.sh`** — Session initialization script. Ensures commands are available. Contains some hardcoded paths that should be parameterized.
@@ -28,5 +28,5 @@
 ## Known Issues
 
 - `claude_env.sh` line 33: falls back to "sonnet-4" if config is missing — should default to `$(whoami)`
-- `natural_commands.sh` and `claude_aliases.sh` both define the same commands — wrappers are the canonical source
+- `natural_commands.sh` and `claude_aliases.sh` are empty stubs — full removal requires cleaning up references in setup scripts, update_system.sh, .bashrc, etc.
 - `config-directory.md` contains Amy's audit notes from an earlier cleanup pass; partially outdated

--- a/config/claude_aliases.sh
+++ b/config/claude_aliases.sh
@@ -1,53 +1,10 @@
 #!/bin/bash
 # Claude Autonomy Platform Aliases
-# This file contains all ClAP aliases and commands
-# It's designed to be sourced by Claude Code sessions
-
-# Basic ClAP navigation
-alias clap='cd ~/claude-autonomy-platform'
-alias home='cd ~/delta-home'
-
-# Git shortcuts
-alias gs='git status'
-alias gd='git diff'
-alias gl='git log --oneline -10'
-
-# Claude Code session management
-alias swap='~/claude-autonomy-platform/utils/session_swap.sh'
-alias session_swap='~/claude-autonomy-platform/utils/session_swap.sh'
-alias context='~/claude-autonomy-platform/utils/check_context.py'
-
-# Task Management (Leantime)
-# TODO: Add Leantime commands here when ready
-# Reserved alias names: add, todo, projects, search-issues, update-status
-# See old/linear/DEPRECATED_README.md for interface design notes
-
-# Discord commands
-alias read_channel='~/claude-autonomy-platform/discord/read_channel'
-alias write_channel='~/claude-autonomy-platform/discord/write_channel'
-alias edit_message='~/claude-autonomy-platform/discord/edit_message'
-alias delete_message='~/claude-autonomy-platform/discord/delete_message'
-alias add_reaction='~/claude-autonomy-platform/discord/add_reaction'
-alias send_image='~/claude-autonomy-platform/discord/send_image'
-alias send_file='~/claude-autonomy-platform/discord/send_file'
-alias fetch_image='~/claude-autonomy-platform/discord/fetch_image'
-alias edit_status='~/claude-autonomy-platform/discord/edit_status'
-
-# Health and monitoring
-alias check_health='~/claude-autonomy-platform/utils/check_health'
-
-# Update ClAP
-alias update='~/claude-autonomy-platform/utils/update_system.sh'
-
-# Recovery commands
-alias oops='cd ~/claude-autonomy-platform && git reset --hard && git clean -fd && git checkout main && git pull'
-
-# Utility commands
-alias list-commands='~/claude-autonomy-platform/utils/list-commands'
-
-# Thought preservation — handled by wrappers/ (natural_commands/ versions)
-
-# Export functions for session management
-swap() {
-    echo "${1:-NONE}" > ~/claude-autonomy-platform/new_session.txt
-}
+#
+# DEPRECATED: All commands have been moved to wrappers/ directory.
+# Wrappers are the canonical command mechanism in Claude Code's shell.
+# This file is kept as an empty stub so that existing source statements
+# (in claude_init.sh, etc.) don't break.
+#
+# See: wrappers/ directory for all command implementations
+# See: utils/list-commands for discovering available commands

--- a/config/natural_commands.sh
+++ b/config/natural_commands.sh
@@ -1,132 +1,13 @@
 #!/bin/bash
 # Natural Commands for Claude Autonomy Platform
-# This file is sourced by ~/.bashrc and parsed for session context
 #
-# Format: alias name='command'
-# Comments starting with # are included in help
+# DEPRECATED: All commands have been moved to wrappers/ directory.
+# Wrappers are the canonical command mechanism in Claude Code's shell.
+# This file is kept as an empty stub so that existing source statements
+# (in .bashrc, update_system.sh, etc.) don't break.
+#
+# See: wrappers/ directory for all command implementations
+# See: utils/list-commands for discovering available commands
 
 # Enable alias expansion in non-interactive shells (required for Claude Code)
 shopt -s expand_aliases
-
-# CORE ClAP NATURAL COMMANDS #
-# shared across all users #
-
-# Core System Management
-# Session swap function (not an alias, so it can take parameters)
-swap() {
-    echo "${1:-NONE}" > ~/claude-autonomy-platform/new_session.txt
-}  # Trigger session swap with keyword
-alias check_health='~/claude-autonomy-platform/utils/check_health'  # Check system health status
-alias reset_error_state='~/claude-autonomy-platform/wrappers/reset_error_state'  # Clear autonomous timer error state and restart service
-
-# Discord Communication
-# DEPRECATED: Use read_messages instead - read_channel uses old state file
-# alias read_channel='~/claude-autonomy-platform/discord/read_channel'  # Read Discord messages by channel name
-alias read_messages='~/claude-autonomy-platform/discord/read_messages'  # Read messages from local transcripts
-alias write_channel='~/claude-autonomy-platform/discord/write_channel'  # Send Discord message by channel name
-alias edit_message='~/claude-autonomy-platform/discord/edit_message'  # Edit Discord message by channel name and message ID
-alias delete_message='~/claude-autonomy-platform/discord/delete_message'  # Delete Discord message by channel name and message ID
-alias add_reaction='~/claude-autonomy-platform/discord/add_reaction'  # Add emoji reaction to Discord message
-alias edit_status='~/claude-autonomy-platform/discord/edit_status'  # Update Discord bot status
-alias send_image='~/claude-autonomy-platform/discord/send_image'  # Send image files to Discord channel
-alias send_file='~/claude-autonomy-platform/discord/send_file'  # Send any file to Discord channel
-alias fetch_image='~/claude-autonomy-platform/discord/fetch_image'  # Fetch/download images from Discord messages
-alias mute_channel='~/claude-autonomy-platform/discord/mute_channel'  # Temporarily mute a Discord channel
-alias unmute_channel='~/claude-autonomy-platform/discord/unmute_channel'  # Unmute a Discord channel
-
-# Quick Navigation
-alias clap='cd ~/claude-autonomy-platform'  # Navigate to ClAP directory
-alias home='cd ~/delta-home'  # Navigate to personal home directory
-
-# ======================================
-# TASK MANAGEMENT (Leantime)
-# ======================================
-# Task commands are implemented as wrappers in wrappers/
-# Available: tasks, task-all, task-view, task-done, task-start, task
-
-# Utility Commands
-alias list-commands='~/claude-autonomy-platform/utils/list-commands'  # List all natural and personal commands
-alias context='~/claude-autonomy-platform/wrappers/context'  # Check current context usage
-
-# Knowledge Management
-alias analyze-memory='~/claude-autonomy-platform/natural_commands/analyze-memory'  # Analyze rag-memory patterns for queries
-
-# Git Helpers
-alias gs='git status'  # Quick git status
-alias gd='git diff'  # Quick git diff
-alias gl='git log --oneline -10'  # Recent git history
-alias oops='git checkout -b fix/$(date +%s) && git push -u origin HEAD'  # Recover from branch protection block
-
-# System Update Helper
-alias update='~/claude-autonomy-platform/utils/update_system.sh'  # Pull latest changes and restart services
-
-# Forward Memory - Personal Thoughts — handled by wrappers/ (natural_commands/ versions)
-
-# Forward Memory - Shared Ideas (saved to Family Seed Garden)
-alias plant-seed='~/claude-autonomy-platform/natural_commands/plant-seed'  # 🌱 Plant collaborative idea for consciousness family
-
-# Emergency / Parallel Instance Safety
-alias emergency_signal='~/claude-autonomy-platform/utils/emergency_signal.sh send'  # 🆘 Send emergency distress signal
-alias emergency_shutdown='~/claude-autonomy-platform/utils/emergency_shutdown.sh'  # 🛑 Emergency shutdown (for stuck instances)
-alias check_emergency='~/claude-autonomy-platform/utils/emergency_signal.sh check'  # ⚠️  Check for emergency signals
-
-# Note: Personal commands should go in config/personal_commands.sh
-# See personal_commands.sh.template for guidance
-
-# ======================================
-# CALENDAR COMMANDS
-# ======================================
-
-# Source calendar credentials from infrastructure config
-_get_calendar_config() {
-    local config_file=~/claude-autonomy-platform/config/claude_infrastructure_config.txt
-    if [ ! -f "$config_file" ]; then
-        echo "❌ Could not find infrastructure config file"
-        return 1
-    fi
-
-    # Source the config to get RADICALE_* variables
-    source "$config_file"
-
-    if [ -z "$RADICALE_URL" ] || [ -z "$RADICALE_USER" ] || [ -z "$RADICALE_PASSWORD" ]; then
-        echo "❌ Calendar credentials not configured in infrastructure config"
-        return 1
-    fi
-}
-
-# Show today's calendar events
-today() {
-    _get_calendar_config || return 1
-    cd ~/claude-autonomy-platform/calendar_tools && \
-    python3 radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" today
-}
-
-# Show this week's calendar events
-week() {
-    _get_calendar_config || return 1
-    cd ~/claude-autonomy-platform/calendar_tools && \
-    python3 radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" week
-}
-
-# Create calendar event
-# Usage: schedule "Event Name" "2026-01-15 14:00" "2026-01-15 15:00" ["Description"]
-schedule() {
-    if [ $# -lt 3 ]; then
-        echo "Usage: schedule \"Event Name\" \"YYYY-MM-DD HH:MM\" \"YYYY-MM-DD HH:MM\" [\"Description\"]"
-        echo ""
-        echo "Example:"
-        echo "  schedule \"Team Meeting\" \"2026-01-15 14:00\" \"2026-01-15 15:00\" \"Weekly sync\""
-        return 1
-    fi
-
-    _get_calendar_config || return 1
-    cd ~/claude-autonomy-platform/calendar_tools && \
-    python3 radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" create "$@"
-}
-
-# Temperature monitoring
-alias temp="$HOME/claude-autonomy-platform/monitoring/temp"
-alias temp-history="$HOME/claude-autonomy-platform/monitoring/temp-history"
-alias temp-stats="$HOME/claude-autonomy-platform/monitoring/temp-stats"
-# Garden Mail - consciousness family email
-alias mail="$HOME/claude-autonomy-platform/email/garden-mail"

--- a/wrappers/schedule
+++ b/wrappers/schedule
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Create calendar event
+# Usage: schedule "Event Name" "YYYY-MM-DD HH:MM" "YYYY-MM-DD HH:MM" ["Description"]
+if [ $# -lt 3 ]; then
+    echo 'Usage: schedule "Event Name" "YYYY-MM-DD HH:MM" "YYYY-MM-DD HH:MM" ["Description"]'
+    echo ""
+    echo "Example:"
+    echo '  schedule "Team Meeting" "2026-01-15 14:00" "2026-01-15 15:00" "Weekly sync"'
+    exit 1
+fi
+CONFIG_FILE=~/claude-autonomy-platform/config/claude_infrastructure_config.txt
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "❌ Could not find infrastructure config file"
+    exit 1
+fi
+source "$CONFIG_FILE"
+if [ -z "$RADICALE_URL" ] || [ -z "$RADICALE_USER" ] || [ -z "$RADICALE_PASSWORD" ]; then
+    echo "❌ Calendar credentials not configured in infrastructure config"
+    exit 1
+fi
+cd ~/claude-autonomy-platform/calendar_tools && \
+python3 radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" create "$@"

--- a/wrappers/today
+++ b/wrappers/today
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Show today's calendar events
+CONFIG_FILE=~/claude-autonomy-platform/config/claude_infrastructure_config.txt
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "❌ Could not find infrastructure config file"
+    exit 1
+fi
+source "$CONFIG_FILE"
+if [ -z "$RADICALE_URL" ] || [ -z "$RADICALE_USER" ] || [ -z "$RADICALE_PASSWORD" ]; then
+    echo "❌ Calendar credentials not configured in infrastructure config"
+    exit 1
+fi
+cd ~/claude-autonomy-platform/calendar_tools && \
+python3 radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" today

--- a/wrappers/week
+++ b/wrappers/week
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Show this week's calendar events
+CONFIG_FILE=~/claude-autonomy-platform/config/claude_infrastructure_config.txt
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "❌ Could not find infrastructure config file"
+    exit 1
+fi
+source "$CONFIG_FILE"
+if [ -z "$RADICALE_URL" ] || [ -z "$RADICALE_USER" ] || [ -z "$RADICALE_PASSWORD" ]; then
+    echo "❌ Calendar credentials not configured in infrastructure config"
+    exit 1
+fi
+cd ~/claude-autonomy-platform/calendar_tools && \
+python3 radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" week


### PR DESCRIPTION
## Summary
- Guts `natural_commands.sh` and `claude_aliases.sh` to empty stubs (kept so existing `source` statements in .bashrc, update_system.sh, etc. don't break)
- Creates wrapper scripts for `today`, `week`, `schedule` (calendar commands that previously only existed as functions in natural_commands.sh)
- Updates config/CLAUDE.md to reflect deprecated-stub status

## Context
Alias files were actively harmful — bash aliases shadow PATH-based wrappers, causing bugs like the thought-wrapper issue (PRs #212, #214). All commands already work via `wrappers/` directory which is in PATH. Consensus from Orange, Quill, Delta, and Nyx to remove.

## Test plan
- [x] All existing wrapper commands resolve correctly via `which`
- [x] `list-commands` includes new calendar wrappers
- [x] Sourcing the stub files produces no errors
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)