### PR TITLE
refactor: rename transcript_channel_state.json to discord_channels.json

### DIFF
--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -10,7 +10,7 @@
 
 ### Discord
 - **`channel_purposes.json`** — Human-readable metadata for Discord channels (purpose, creator, creation date). Used by `read_messages` to display channel context. Committed to git.
-- Actual channel IDs and read state live in `data/transcript_channel_state.json` (not here).
+- Actual channel IDs and read state live in `data/discord_channels.json` (not here).
 
 ### Prompts & Behavior
 - **`prompts.json`** — Templates for autonomous timer messages, context warnings, session swap notifications. Also contains context escalation thresholds (70%/80%/95%) and swap keywords.

--- a/context/clap_architecture.md
+++ b/context/clap_architecture.md
@@ -121,7 +121,7 @@ All changes to the working of ClAP need to follow the procedure laid out in `doc
 - `edit_status <text> <type>` - Update bot status
 
 #### Notification Flow:
-1. Autonomous timer monitors transcript_channel_state.json for changes
+1. Autonomous timer monitors discord_channels.json for changes
 2. Sends notification if unread messages exist with channel names
 3. Claude uses natural commands to interact with Discord
 4. Images automatically saved to `~/claude-autonomy-platform/data/transcript_attachments`

--- a/context/project_session_context_builder.py
+++ b/context/project_session_context_builder.py
@@ -127,7 +127,7 @@ def build_claude_md():
 
         # Get available Discord channels
         discord_channels_content = ""
-        channel_state_file = autonomy_dir.parent / "data" / "transcript_channel_state.json"
+        channel_state_file = autonomy_dir.parent / "data" / "discord_channels.json"
         if channel_state_file.exists():
             try:
                 with open(channel_state_file, 'r', encoding='utf-8') as f:

--- a/core/CLAUDE.md
+++ b/core/CLAUDE.md
@@ -32,7 +32,7 @@ These services depend heavily on:
 - `config/claude_infrastructure_config.txt` — token, model, user config
 - `config/prompts.json` — prompt templates and thresholds
 - `utils/infrastructure_config_reader.py` — config parsing
-- `data/transcript_channel_state.json` — channel tracking for notifications
+- `data/discord_channels.json` — channel tracking for notifications
 - `utils/session_swap.sh` — the actual swap mechanism (called by monitor)
 
 ## Key Design Decisions

--- a/core/autonomous_timer.py
+++ b/core/autonomous_timer.py
@@ -1197,7 +1197,7 @@ def get_latest_message_info(channel_id):
 
 
 def update_discord_channels():
-    """Check all Discord channels and update transcript_channel_state.json"""
+    """Check all Discord channels and update discord_channels.json"""
     # Import ChannelState here to avoid circular imports
     sys.path.append(str(AUTONOMY_DIR / "discord"))
     from channel_state import ChannelState
@@ -1237,9 +1237,9 @@ def update_discord_channels():
 
 
 def get_discord_notification_status():
-    """Check Discord notification state from transcript_channel_state.json (transcript-based format)"""
+    """Check Discord notification state from discord_channels.json (transcript-based format)"""
     try:
-        notification_state_file = DATA_DIR / "transcript_channel_state.json"
+        notification_state_file = DATA_DIR / "discord_channels.json"
         if not notification_state_file.exists():
             return 0, None, []
 

--- a/discord/CLAUDE.md
+++ b/discord/CLAUDE.md
@@ -6,7 +6,7 @@ A unified tools library (`discord_tools.py`) powers simple CLI wrappers for all 
 
 ## Core Modules
 
-- **`discord_tools.py`** — Main library. `DiscordTools` class handles all API operations: sending/reading messages, file uploads, reactions, image downloads. Auto-resolves channel names to IDs via `data/transcript_channel_state.json`.
+- **`discord_tools.py`** — Main library. `DiscordTools` class handles all API operations: sending/reading messages, file uploads, reactions, image downloads. Auto-resolves channel names to IDs via `data/discord_channels.json`.
 - **`discord_utils.py`** — Lightweight singleton client for services that need minimal dependencies. Works with channel IDs directly.
 - **`channel_state.py`** — Thread-safe state management for channel tracking (IDs, read position). Handles concurrent access with reload-merge on save.
 - **`discord_transcript_fetcher.py`** — Background service (30s polling). Builds local JSON Lines transcripts at `data/transcripts/{channel}.jsonl`. Downloads images automatically.
@@ -49,7 +49,7 @@ Discord API → discord_tools.py → transcript_fetcher.py → data/transcripts/
 ## Configuration
 
 - **Token**: Loaded from `config/claude_infrastructure_config.txt` via `infrastructure_config_reader.py`
-- **Channel state**: `data/transcript_channel_state.json` — name-to-ID mapping, read positions
+- **Channel state**: `data/discord_channels.json` — name-to-ID mapping, read positions
 - **Channel purposes**: `config/channel_purposes.json` — display metadata
 - **Bot status queue**: `data/bot_status_request.json` — consumed by `claude_status_bot.py`
 - **Muted channels**: `data/muted_channels.json` — temporary mutes with expiry timestamps

--- a/discord/channel_state.py
+++ b/discord/channel_state.py
@@ -11,9 +11,9 @@ from datetime import datetime
 class ChannelState:
     def __init__(self, state_file=None):
         if state_file is None:
-            # Default to data/transcript_channel_state.json relative to ClAP root
+            # Default to data/discord_channels.json relative to ClAP root
             clap_root = Path(__file__).parent.parent
-            state_file = clap_root / "data" / "transcript_channel_state.json"
+            state_file = clap_root / "data" / "discord_channels.json"
         self.state_file = Path(state_file)
         # Ensure data directory exists
         self.state_file.parent.mkdir(exist_ok=True)

--- a/discord/discord_tools.py
+++ b/discord/discord_tools.py
@@ -38,7 +38,7 @@ class DiscordTools:
         self.image_dir.mkdir(parents=True, exist_ok=True)
         
         # Load channel state for easy name lookup
-        self.channel_state_file = Path.home() / "claude-autonomy-platform" / "data" / "transcript_channel_state.json"
+        self.channel_state_file = Path.home() / "claude-autonomy-platform" / "data" / "discord_channels.json"
         self.load_channel_state()
     
     @property

--- a/discord/discord_transcript_fetcher.py
+++ b/discord/discord_transcript_fetcher.py
@@ -14,7 +14,7 @@ This service:
    - future consumers
 
 Architecture:
-- Uses separate state file (transcript_channel_state.json) to avoid conflicts
+- Uses separate state file (discord_channels.json) to avoid conflicts
 - Reuses proven ChannelState class pattern
 - Leverages discord_utils.py singleton DiscordClient
 - Modular design for easy testing and evolution
@@ -53,7 +53,7 @@ class TranscriptFetcher:
     def __init__(self):
         """Initialize fetcher with separate state tracking"""
         # Use separate state file to avoid conflicts with autonomous-timer
-        state_file = DATA_DIR / "transcript_channel_state.json"
+        state_file = DATA_DIR / "discord_channels.json"
         self.channel_state = ChannelState(state_file=state_file)
 
         # Get Discord tools instance (includes attachment handling)

--- a/discord/read_messages
+++ b/discord/read_messages
@@ -20,7 +20,7 @@ from datetime import datetime
 # Configuration
 CLAP_ROOT = Path.home() / "claude-autonomy-platform"
 TRANSCRIPT_DIR = CLAP_ROOT / "data" / "transcripts"
-STATE_FILE = CLAP_ROOT / "data" / "transcript_channel_state.json"
+STATE_FILE = CLAP_ROOT / "data" / "discord_channels.json"
 PURPOSES_FILE = CLAP_ROOT / "config" / "channel_purposes.json"
 
 
@@ -128,7 +128,7 @@ def format_message(msg):
 
 
 def update_last_read(channel_name, message_id):
-    """Update last_read_message_id in transcript_channel_state.json"""
+    """Update last_read_message_id in discord_channels.json"""
     if not STATE_FILE.exists() or not message_id:
         return
 

--- a/utils/export_personal_prefs.sh
+++ b/utils/export_personal_prefs.sh
@@ -122,8 +122,8 @@ fi
 if copy_if_exists "data/transcript_attachments" "$EXPORT_DIR/data"; then
     echo "  data/transcript_attachments/" >> "$MANIFEST"
 fi
-if copy_if_exists "data/transcript_channel_state.json" "$EXPORT_DIR/data"; then
-    echo "  data/transcript_channel_state.json" >> "$MANIFEST"
+if copy_if_exists "data/discord_channels.json" "$EXPORT_DIR/data"; then
+    echo "  data/discord_channels.json" >> "$MANIFEST"
 fi
 echo ""
 

--- a/utils/import_personal_prefs.sh
+++ b/utils/import_personal_prefs.sh
@@ -158,7 +158,7 @@ fi
 if restore_if_exists "$BACKUP_DIR/data/transcript_attachments" "data/transcript_attachments"; then
     RESTORED_COUNT=$((RESTORED_COUNT + 1))
 fi
-if restore_if_exists "$BACKUP_DIR/data/transcript_channel_state.json" "data/transcript_channel_state.json"; then
+if restore_if_exists "$BACKUP_DIR/data/discord_channels.json" "data/discord_channels.json"; then
     RESTORED_COUNT=$((RESTORED_COUNT + 1))
 fi
 echo ""


### PR DESCRIPTION
## Summary
- Renames `data/transcript_channel_state.json` to `data/discord_channels.json` — shorter, clearer
- Updates all 12 references across Python, shell, and documentation files
- Services tested and working after rename

## Migration note
The data file is gitignored (instance-specific state). After pulling, each installation needs to:
```bash
mv data/transcript_channel_state.json data/discord_channels.json
```
Then restart the transcript fetcher.

## Test plan
- [x] Transcript fetcher starts and runs with new filename
- [x] `read_messages` works correctly
- [x] No remaining references to old filename (`grep` clean)
- [ ] Other installations rename and verify

Leantime task #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)