### PR TITLE
fix: replace hardcoded fallbacks in claude_env.sh

### DIFF
--- a/config/claude_env.sh
+++ b/config/claude_env.sh
@@ -29,11 +29,11 @@ read_config() {
 CLAUDE_USER=$(read_config "LINUX_USER")
 PERSONAL_REPO=$(read_config "PERSONAL_REPO")
 
-# Set paths using config values
-export CLAUDE_USER=${CLAUDE_USER:-sonnet-4}
+# Set paths using config values (fall back to current user if config unreadable)
+export CLAUDE_USER=${CLAUDE_USER:-$(whoami)}
 export CLAUDE_HOME=${CLAUDE_HOME:-$(eval echo ~$CLAUDE_USER)}
 export AUTONOMY_DIR=${AUTONOMY_DIR:-$CLAUDE_HOME/claude-autonomy-platform}
-export PERSONAL_DIR=${PERSONAL_DIR:-$CLAUDE_HOME/$PERSONAL_REPO}
+export PERSONAL_DIR=${PERSONAL_DIR:-$CLAUDE_HOME/${PERSONAL_REPO:-${CLAUDE_USER}-home}}
 export CLAUDE_CONFIG_DIR=${CLAUDE_CONFIG_DIR:-$CLAUDE_HOME/.config/Claude}
 # Get the ClAP directory (parent of config directory)
 # This works regardless of where the script is sourced from


### PR DESCRIPTION
## Summary
- CLAUDE_USER fallback changed from `sonnet-4` to `$(whoami)` — the old default was a model name, not a username
- PERSONAL_DIR fallback now uses `${CLAUDE_USER}-home` convention instead of empty string when PERSONAL_REPO is unset

## Test plan
- [x] Sourcing the file produces correct values for all paths
- [ ] Other installations verify correct behavior

Leantime task #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)