### PR TITLE
fix: remove hardcoded paths from claude_init.sh

### DIFF
--- a/config/claude_init.sh
+++ b/config/claude_init.sh
@@ -2,20 +2,15 @@
 # Claude Code Session Initialization
 # This script ensures all ClAP commands are available in Claude Code sessions
 
-# Source environment variables first
+# Source environment variables first (sets CLAP_DIR, PERSONAL_DIR, etc.)
 if [ -f "$HOME/claude-autonomy-platform/config/claude_env.sh" ]; then
     source "$HOME/claude-autonomy-platform/config/claude_env.sh"
 fi
 
-# Source aliases
-if [ -f "$HOME/claude-autonomy-platform/config/claude_aliases.sh" ]; then
-    source "$HOME/claude-autonomy-platform/config/claude_aliases.sh"
-fi
-
 # Add ClAP directories to PATH
-export PATH="$HOME/claude-autonomy-platform/utils:$PATH"
-export PATH="$HOME/claude-autonomy-platform/discord:$PATH"
-export PATH="$HOME/delta-home/tools:$PATH"
+export PATH="${CLAP_DIR:-$HOME/claude-autonomy-platform}/utils:$PATH"
+export PATH="${CLAP_DIR:-$HOME/claude-autonomy-platform}/discord:$PATH"
+export PATH="${PERSONAL_DIR:-$HOME}/tools:$PATH"
 export PATH="$HOME/bin:$PATH"
 
 # Ensure proper locale for ansible


### PR DESCRIPTION
## Summary
- Replaces hardcoded `delta-home/tools` with `${PERSONAL_DIR}/tools`
- Uses `${CLAP_DIR}` for ClAP paths (with HOME fallback)
- Removes dead `source` of empty `claude_aliases.sh` stub

## Test plan
- [x] Script sources correctly and sets PATH
- [ ] Other installations verify PATH includes their personal tools dir

Leantime tasks #132, #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)