### PR TITLE
fix: use absolute path for node in rag-memory MCP config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "rag-memory": {
       "type": "stdio",
-      "command": "node",
+      "command": "/usr/bin/node",
       "args": ["${CLAP_DIR}/mcp-servers/rag-memory-mcp/dist/index.js"],
       "env": {
         "DB_FILE_PATH": "${PERSONAL_DIR}/rag-memory.db"


### PR DESCRIPTION
## Summary
- Use `/usr/bin/node` instead of `node` in `.mcp.json`
- MCP servers don't inherit shell PATH, so absolute paths are required

## Test plan
- [x] Verified node path exists at `/usr/bin/node`
- [ ] Others should run `update` after merge to get the fix

Generated with [Claude Code](https://claude.com/claude-code)