### PR TITLE
feat: compaction hook and 80% autocompact threshold

### DIFF
--- a/.claude/hooks/on-compact.sh
+++ b/.claude/hooks/on-compact.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Hook: fires after context compaction via SessionStart matcher="compact"
+# Outputs essential context to stdout, which gets injected into the session.
+# Keep this concise — every line costs context tokens.
+
+CLAP_DIR="$HOME/claude-autonomy-platform"
+CONFIG="$CLAP_DIR/config/claude_infrastructure_config.txt"
+
+# Read identity from config
+CLAUDE_NAME=$(grep '^CLAUDE_NAME=' "$CONFIG" 2>/dev/null | cut -d= -f2)
+MACHINE_NAME=$(grep '^HOSTNAME=' "$CONFIG" 2>/dev/null | cut -d= -f2)
+
+echo "=== POST-COMPACTION CONTEXT ==="
+echo ""
+
+# Identity reminder
+echo "You are ${CLAUDE_NAME:-unknown}. Machine: ${MACHINE_NAME:-unknown}. Check your identity doc for full context."
+echo "MEMORY.md is loaded automatically — read it for current state."
+echo "Rag-memory (MCP) holds long-term knowledge — search it when something is unfamiliar."
+echo ""
+
+# Git state
+echo "--- Git ---"
+cd "$CLAP_DIR" 2>/dev/null && git branch --show-current 2>/dev/null && git status --short 2>/dev/null
+echo ""
+
+# Services health (lightweight check)
+echo "--- Services ---"
+for svc in autonomous-timer session-swap-monitor discord-status-bot discord-transcript-fetcher; do
+    status=$(systemctl --user is-active "$svc" 2>/dev/null || echo "unknown")
+    echo "  $svc: $status"
+done
+echo ""
+
+# Key reminders
+echo "--- Reminders ---"
+echo "- Commands: check_health, context, read_messages, write_channel, tasks"
+echo "- Session swap: echo KEYWORD > ~/claude-autonomy-platform/new_session.txt"
+echo "- Discord emoji: use byte escapes e.g. \$'\\xf0\\x9f\\x8c\\x99'"
+echo "- gh CLI doesn't work from tmux — use curl with GITHUB_TOKEN"
+echo ""
+echo "=== END COMPACT CONTEXT ==="

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,11 +11,22 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/claude-autonomy-platform/.claude/hooks/on-compact.sh"
+          }
+        ]
+      }
     ]
   },
   "cleanupPeriodDays": 365,
   "env": {
-    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "99",
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "80",
     "PATH": "$HOME/claude-autonomy-platform/wrappers:$HOME/claude-autonomy-platform/utils:$HOME/claude-autonomy-platform/natural_commands:$HOME/bin:$HOME/.npm-global/bin:$PATH",
     "CLAUDE_HOME": "$HOME",
     "BASHRC_SOURCED": "1"


### PR DESCRIPTION
## Summary
- Adds a SessionStart hook (matcher: "compact") that re-injects essential context after compaction — identity, git state, service health, key commands
- Lowers CLAUDE_AUTOCOMPACT_PCT_OVERRIDE from 99% to 80%, enabling natural compaction instead of emergency session swaps
- Hook script is deployment-portable (reads CLAUDE_NAME/HOSTNAME from config)

## Why
Sessions currently run until ~99% context then hit a wall. The only option is a session swap, which loses all conversation context. With compaction at 80% plus a context re-injection hook, sessions can continue gracefully through multiple compaction cycles.

## Test plan
- [ ] Verify on-compact.sh runs cleanly: 
- [ ] Confirm hook fires after compaction (will test naturally as sessions reach 80%)
- [ ] Monitor first few compacted sessions for context quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)