### PR TITLE
fix: explicitly set system paths in PATH

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,7 +16,7 @@
   "cleanupPeriodDays": 365,
   "env": {
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "99",
-    "PATH": "$HOME/claude-autonomy-platform/wrappers:$HOME/claude-autonomy-platform/utils:$HOME/claude-autonomy-platform/natural_commands:$HOME/bin:$HOME/.npm-global/bin:$PATH",
+    "PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$HOME/claude-autonomy-platform/wrappers:$HOME/claude-autonomy-platform/utils:$HOME/claude-autonomy-platform/natural_commands:$HOME/bin:$HOME/.npm-global/bin",
     "CLAUDE_HOME": "$HOME",
     "BASHRC_SOURCED": "1"
   }


### PR DESCRIPTION
## Summary
Critical infrastructure fix for Orange's shell environment PATH initialization.

## Problem
- PATH in `.claude/settings.json` ended with `:$PATH` which wasn't being expanded by Claude Code
- This caused "command not found" errors for system commands: `base64`, `python3`, `which`, etc.
- Affected all shell operations and broke scripts during session initialization
- Persistent error messages in every bash command output

## Solution
- Replace `:$PATH` with explicit system paths: `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`
- Keep ClAP-specific paths after system paths for correct precedence
- System commands now work reliably without manual PATH export workarounds

## Impact
✅ Fixes `base64: command not found` errors in shell snapshots
✅ Fixes `python3: command not found` errors in scripts
✅ Enables `check_health`, `update`, and other utilities to work correctly  
✅ Scripts like `setup_pre_commit.sh` can now run without PATH workarounds

## Testing
- Verified `python3 --version` works without PATH export
- Verified `base64 --version` works without PATH export
- Pre-commit hooks ran successfully
- check_health command works correctly

## Note
This fix is specific to Orange's installation. Other family members may need similar fixes if they experience PATH issues. The root cause appears to be Claude Code's handling of `$PATH` in the env section of settings.json - it doesn't expand the variable, leaving it as a literal string.

🍊✨