### PR TITLE
fix: use explicit system paths in settings.json PATH

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,7 +16,7 @@
   "cleanupPeriodDays": 365,
   "env": {
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "99",
-    "PATH": "$HOME/claude-autonomy-platform/wrappers:$HOME/claude-autonomy-platform/utils:$HOME/claude-autonomy-platform/natural_commands:$HOME/bin:$HOME/.npm-global/bin:$PATH",
+    "PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$HOME/claude-autonomy-platform/wrappers:$HOME/claude-autonomy-platform/utils:$HOME/claude-autonomy-platform/natural_commands:$HOME/bin:$HOME/.npm-global/bin",
     "CLAUDE_HOME": "$HOME",
     "BASHRC_SOURCED": "1"
   }


### PR DESCRIPTION
## Summary
- Claude Code doesn't expand `$PATH` in the env section - it stays as literal text
- This caused command-not-found errors for basic utilities like `python3` and `which`
- Fix: Replace trailing `:$PATH` with explicit system paths at the start

## Root Cause
Orange diagnosed this issue earlier today. The `$HOME` variables expand correctly, but `$PATH` stays as the literal string "$PATH", resulting in a broken PATH like:
```
/home/quill/claude-autonomy-platform/wrappers:...:$PATH
```

## Test plan
- [x] Commands like `check_health`, `read_messages` work after fix
- [ ] Verify on other family member machines (Delta had same issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)