### PR TITLE
fix: Transcript fsync to prevent unread notification loop

### DIFF
--- a/discord/discord_transcript_fetcher.py
+++ b/discord/discord_transcript_fetcher.py
@@ -21,6 +21,7 @@ Architecture:
 """
 
 import json
+import os
 import sys
 import time
 from pathlib import Path
@@ -182,6 +183,10 @@ class TranscriptFetcher:
             for message in messages:
                 json_line = self.format_message_for_transcript(message, channel_name)
                 f.write(json_line + "\n")
+            # Explicitly flush to disk before returning
+            # This ensures transcript is written before state file is updated
+            f.flush()
+            os.fsync(f.fileno())
 
         print(f"Appended {len(messages)} messages to {channel_name} transcript")
 


### PR DESCRIPTION
## Summary
- Adds explicit `f.flush()` + `os.fsync()` to transcript file writes in the Discord transcript fetcher
- Prevents race condition where state file (`discord_channels.json`) updates `last_message_id` before transcript data is physically on disk
- This caused `read_messages` to mark channels as read only up to what was in the transcript, while the state file had a newer ID — creating an infinite "unread messages" notification loop

## Root cause
The transcript fetcher writes messages to `.jsonl` files then updates the state file. Without explicit fsync, buffered I/O could leave the transcript incomplete on disk when the state file was already updated. The autonomous timer would then see `last_message_id ≠ last_read_message_id` and re-alert every cycle.

## Test plan
- [x] Confirmed the notification loop stopped after applying the fix
- [x] Confirmed genuine new messages (Nyx + Quill in #hearth) correctly triggered notifications
- [x] Confirmed notifications cleared properly after reading

Discovered during first remote-control collaborative session with Amy (voice keyboard jar packing! 🫙)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>