### PR TITLE
fix: improve temp throttling display to reduce false alarms

### DIFF
--- a/monitoring/temp
+++ b/monitoring/temp
@@ -21,7 +21,20 @@ if command -v vcgencmd &> /dev/null; then
     # Also show throttling status
     THROTTLED=$(vcgencmd get_throttled | cut -d= -f2)
     if [ "$THROTTLED" != "0x0" ]; then
-        echo -e "⚠️  \033[31mTHROTTLING ACTIVE: $THROTTLED\033[0m"
+        # Convert hex to decimal for bit operations
+        THROTTLED_DEC=$((THROTTLED))
+
+        # Check current throttling (bits 0-3)
+        CURRENT_THROTTLE=$((THROTTLED_DEC & 0xF))
+
+        # Check historical throttling (bits 16-19)
+        HISTORICAL_THROTTLE=$((THROTTLED_DEC & 0xF0000))
+
+        if [ "$CURRENT_THROTTLE" -ne 0 ]; then
+            echo -e "⚠️  \033[31mCURRENTLY THROTTLED\033[0m"
+        elif [ "$HISTORICAL_THROTTLE" -ne 0 ]; then
+            echo -e "ℹ️  \033[33mThrottling occurred since boot\033[0m (not active now)"
+        fi
     fi
 else
     # Generic Linux


### PR DESCRIPTION
## Summary
- Fixed misleading "THROTTLING ACTIVE" message that shows for historical throttling events
- Now properly distinguishes between current throttling and past events
- Reduces unnecessary anxiety when monitoring temperatures

## Changes
The temp command now checks throttling bits properly:
- Bits 0-3: Current throttling state → shows "CURRENTLY THROTTLED" (red)
- Bits 16-19: Historical flags → shows "Throttling occurred since boot (not active now)" (yellow)

## Test Output
Before: `⚠️  THROTTLING ACTIVE: 0xe0000` (alarming even when not throttling)
After: `ℹ️  Throttling occurred since boot (not active now)` (accurate and less anxiety-inducing)

## Context
The vmemory bug was causing the temp command to display alarming messages even when the system was running fine. Amy noticed this was causing unnecessary anxiety about temperatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)