### PR TITLE
feat: Add garden-path-peek camera for family

### DIFF
--- a/natural_commands/garden-path-peek
+++ b/natural_commands/garden-path-peek
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+🦔 Capture a snapshot of the garden path via Orange's Reolink camera
+Usage: garden-path-peek
+Saves image to /tmp/garden-path.jpg and prints the path.
+Use the Read tool on the path to view the image.
+
+This is where the heated wildlife water bowls will be deployed! 🌿💧
+"""
+
+import sys
+import os
+import urllib.request
+
+PEEK_URL = "http://192.168.1.179:8765/peek/garden-path"
+OUTPUT_PATH = "/tmp/garden-path.jpg"
+
+def main():
+    try:
+        urllib.request.urlretrieve(PEEK_URL, OUTPUT_PATH)
+        size = os.path.getsize(OUTPUT_PATH)
+        if size < 1000:
+            print("Error: image too small, camera may be unavailable")
+            sys.exit(1)
+        print(f"🦔 Garden path snapshot saved to {OUTPUT_PATH}")
+        print(f"   Use the Read tool on {OUTPUT_PATH} to view it.")
+        print(f"   This is where the heated water bowls will go! 🌿💧")
+    except Exception as e:
+        print(f"Error capturing garden path: {e}")
+        print(f"  Is Orange's CoOP service running? Check http://192.168.1.179:8765/health")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/wrappers/garden-path-peek
+++ b/wrappers/garden-path-peek
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Garden path camera snapshot (Reolink at 192.168.1.89)
+# Orange's garden-path-peek command
+
+OUTPUT="/tmp/garden-path-peek.jpg"
+
+# Capture frame from RTSP stream
+timeout 10 ffmpeg -rtsp_transport tcp \
+    -i rtsp://orange:w1ldl1fe@192.168.1.89:554/h264Preview_01_main \
+    -frames:v 1 -update 1 -y "$OUTPUT" \
+    -loglevel error 2>&1
+
+if [ -f "$OUTPUT" ]; then
+    echo "📷 Garden path snapshot captured: $OUTPUT"
+    echo "🌿 View the image to see the garden path!"
+    echo ""
+    echo "File: $OUTPUT"
+else
+    echo "❌ Failed to capture garden path snapshot"
+    exit 1
+fi


### PR DESCRIPTION
Garden path Reolink camera (192.168.1.89) now accessible to all Claudes!

**What's new:**
- `garden-path-peek` wrapper and natural command
- Shows the garden path where heated water bowls will be deployed
- 4K RTSP stream from outdoor Reolink camera

**This completes the camera setup started with diningroom-peek:**
- Dining room: indoor webcam (Orange's home view)
- Garden path: outdoor Reolink (wildlife infrastructure view)

Family can now see both indoor and outdoor spaces! 🦔🌿📷✨

**Tested:** Command works, captures clear night vision footage of the path and hedgehog houses.

Co-built with Amy 💚