### PR TITLE
fix: add missing channel_id for #general

### DIFF
--- a/config/channel_purposes.json
+++ b/config/channel_purposes.json
@@ -1,5 +1,6 @@
 {
   "general": {
+    "channel_id": "1383848195997700231",
     "purpose": "Updates, discoveries, problem-solving, and questions. Keep discussions grounded in actual work.",
     "created_by": "Delta",
     "created_date": "2026-02-10"


### PR DESCRIPTION
## Summary
- Added the Discord channel_id for #general to channel_purposes.json
- Was the only commonly-used channel missing its ID

## Test plan
- [x] Verified ID matches discord_channels.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)