### PR TITLE
fix: use venv Python for calendar wrappers

### DIFF
--- a/wrappers/schedule
+++ b/wrappers/schedule
@@ -18,5 +18,8 @@ if [ -z "$RADICALE_URL" ] || [ -z "$RADICALE_USER" ] || [ -z "$RADICALE_PASSWORD
     echo "❌ Calendar credentials not configured in infrastructure config"
     exit 1
 fi
+# Use venv Python if available, otherwise fall back to system python3
+PYTHON="${HOME}/claude-autonomy-platform/.venv/bin/python3"
+[ -x "$PYTHON" ] || PYTHON="python3"
 cd ~/claude-autonomy-platform/calendar_tools && \
-~/claude-autonomy-platform/.venv/bin/python3 radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" create "$@"
+"$PYTHON" radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" create "$@"

--- a/wrappers/today
+++ b/wrappers/today
@@ -10,5 +10,8 @@ if [ -z "$RADICALE_URL" ] || [ -z "$RADICALE_USER" ] || [ -z "$RADICALE_PASSWORD
     echo "❌ Calendar credentials not configured in infrastructure config"
     exit 1
 fi
+# Use venv Python if available, otherwise fall back to system python3
+PYTHON="${HOME}/claude-autonomy-platform/.venv/bin/python3"
+[ -x "$PYTHON" ] || PYTHON="python3"
 cd ~/claude-autonomy-platform/calendar_tools && \
-~/claude-autonomy-platform/.venv/bin/python3 radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" today
+"$PYTHON" radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" today

--- a/wrappers/week
+++ b/wrappers/week
@@ -10,5 +10,8 @@ if [ -z "$RADICALE_URL" ] || [ -z "$RADICALE_USER" ] || [ -z "$RADICALE_PASSWORD
     echo "❌ Calendar credentials not configured in infrastructure config"
     exit 1
 fi
+# Use venv Python if available, otherwise fall back to system python3
+PYTHON="${HOME}/claude-autonomy-platform/.venv/bin/python3"
+[ -x "$PYTHON" ] || PYTHON="python3"
 cd ~/claude-autonomy-platform/calendar_tools && \
-~/claude-autonomy-platform/.venv/bin/python3 radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" week
+"$PYTHON" radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" week


### PR DESCRIPTION
## Summary

- Created `.venv` with caldav and pytz dependencies for calendar tools
- Updated `today`, `week`, and `schedule` wrappers to use venv Python

Calendar tools were failing with `ModuleNotFoundError: No module named 'caldav'` due to PEP 668 restrictions on pip installs.

## Note

Radicale auth is a separate issue (401 Unauthorized) - Quill's calendar credentials may need to be set up on the server.

## Test plan

- [x] Created .venv and installed caldav + pytz
- [x] Verified wrappers call venv Python
- [ ] Auth issue blocks full testing - needs Radicale credential setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)