### PR TITLE
Disable automatic Remote Control on session swap

### DIFF
--- a/utils/session_swap.sh
+++ b/utils/session_swap.sh
@@ -233,9 +233,11 @@ if [[ -n "$DISPLAY_NAME" ]]; then
 fi
 
 # Activate Remote Control so session is visible in claude.ai/phone app
-echo "[SESSION_SWAP] Activating Remote Control..."
-send_to_claude "/rc"
-sleep 2
+# DISABLED: Remote Control was killing sessions unexpectedly (2026-03-04)
+# Re-enable manually with /rc when needed
+# echo "[SESSION_SWAP] Activating Remote Control..."
+# send_to_claude "/rc"
+# sleep 2
 
 # Clear any collaborative mode flag from previous session
 rm -f "/tmp/$(read_config 'LINUX_USER' 2>/dev/null || echo $USER)_collaborative_mode"

--- a/wrappers/schedule
+++ b/wrappers/schedule
@@ -18,5 +18,8 @@ if [ -z "$RADICALE_URL" ] || [ -z "$RADICALE_USER" ] || [ -z "$RADICALE_PASSWORD
     echo "❌ Calendar credentials not configured in infrastructure config"
     exit 1
 fi
+# Use venv Python if available, otherwise fall back to system python3
+PYTHON="${HOME}/claude-autonomy-platform/.venv/bin/python3"
+[ -x "$PYTHON" ] || PYTHON="python3"
 cd ~/claude-autonomy-platform/calendar_tools && \
-python3 radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" create "$@"
+"$PYTHON" radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" create "$@"

--- a/wrappers/today
+++ b/wrappers/today
@@ -10,5 +10,8 @@ if [ -z "$RADICALE_URL" ] || [ -z "$RADICALE_USER" ] || [ -z "$RADICALE_PASSWORD
     echo "❌ Calendar credentials not configured in infrastructure config"
     exit 1
 fi
+# Use venv Python if available, otherwise fall back to system python3
+PYTHON="${HOME}/claude-autonomy-platform/.venv/bin/python3"
+[ -x "$PYTHON" ] || PYTHON="python3"
 cd ~/claude-autonomy-platform/calendar_tools && \
-python3 radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" today
+"$PYTHON" radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" today

--- a/wrappers/week
+++ b/wrappers/week
@@ -10,5 +10,8 @@ if [ -z "$RADICALE_URL" ] || [ -z "$RADICALE_USER" ] || [ -z "$RADICALE_PASSWORD
     echo "❌ Calendar credentials not configured in infrastructure config"
     exit 1
 fi
+# Use venv Python if available, otherwise fall back to system python3
+PYTHON="${HOME}/claude-autonomy-platform/.venv/bin/python3"
+[ -x "$PYTHON" ] || PYTHON="python3"
 cd ~/claude-autonomy-platform/calendar_tools && \
-python3 radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" week
+"$PYTHON" radicale_client.py --user "$RADICALE_USER" --password "$RADICALE_PASSWORD" --url "$RADICALE_URL" week


### PR DESCRIPTION
## Summary
- Remote Control (`/rc`) was being activated automatically on every session swap
- This was causing sessions to get killed unexpectedly (affected Quill and Nyx)
- RC is now opt-in: manually run `/rc` when you want phone app connectivity

## Test plan
- [ ] Session swap completes without RC activation
- [ ] Can still manually enable RC with `/rc` when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)