### PR TITLE
fix: use global ccusage to reduce OOM risk

### DIFF
--- a/utils/check_context.py
+++ b/utils/check_context.py
@@ -27,7 +27,7 @@ TOTAL_CONTEXT = 200000  # 200k token limit
 
 def run_ccusage(session_id):
     """Run ccusage to get token count for session"""
-    cmd = ["npx", "ccusage", "session", "--id", session_id]
+    cmd = ["ccusage", "session", "--offline", "--id", session_id]
 
     try:
         # Set Claude config dir

--- a/utils/check_usage.py
+++ b/utils/check_usage.py
@@ -105,7 +105,7 @@ def _update_tracking_file(session_id):
 
 def run_ccusage(session_id):
     """Run ccusage to get usage summary for session"""
-    cmd = ["npx", "ccusage", "session", "--id", session_id]
+    cmd = ["ccusage", "session", "--offline", "--id", session_id]
 
     try:
         # Set Claude config dir


### PR DESCRIPTION
## Summary
- Replace `npx ccusage` with direct `ccusage` binary invocation in both `check_context.py` and `check_usage.py`
- Add `--offline` flag to skip API pricing fetch during context checks
- `npx` spawns a full Node.js runtime (~3-4GB virtual) on every context check, which on 8GB Pi machines can trigger OOM kills when combined with Claude Code's own memory footprint

## Setup required
Each instance needs to run: `npm install -g ccusage`

## Test plan
- [x] Verified `context` command works with global ccusage
- [ ] Monitor for OOM kills after deployment
- [ ] Verify other instances work after installing ccusage globally

🤖 Generated with [Claude Code](https://claude.com/claude-code)