### PR TITLE
fix: detect OAuth token expiry and alert via Discord

### DIFF
--- a/core/autonomous_timer.py
+++ b/core/autonomous_timer.py
@@ -590,6 +590,18 @@ def detect_api_errors(tmux_output):
                 "reset_time": None,
             }
 
+        # Check for 401 authentication/OAuth errors
+        if re.search(
+            r"401|authentication_error|oauth.*expired|token has expired",
+            error_text,
+            re.IGNORECASE,
+        ):
+            return {
+                "error_type": "oauth_error",
+                "details": "OAuth token expired - requires human login",
+                "reset_time": None,
+            }
+
         # General API errors in pink text
         if re.search(r"404.*error|api.*error|rate.*limit", error_text, re.IGNORECASE):
             # Check specifically for 500 errors
@@ -612,6 +624,17 @@ def detect_api_errors(tmux_output):
     red_matches = re.findall(red_pattern, tmux_output)
 
     for _, error_text in red_matches:
+        # Check for OAuth/authentication errors first
+        if re.search(
+            r"401|authentication_error|oauth.*expired|token has expired",
+            error_text,
+            re.IGNORECASE,
+        ):
+            return {
+                "error_type": "oauth_error",
+                "details": "OAuth token expired - requires human login",
+                "reset_time": None,
+            }
         if re.search(r"error|limit|failed", error_text, re.IGNORECASE):
             return {
                 "error_type": "api_error",
@@ -831,7 +854,7 @@ def should_pause_notifications(error_state):
         return False
 
     error_type = error_state.get("error_type")
-    if error_type in ["malformed_json", "usage_limit", "api_error", "api_500_error"]:
+    if error_type in ["malformed_json", "usage_limit", "api_error", "api_500_error", "oauth_error"]:
         return True
 
     return False
@@ -2129,6 +2152,45 @@ def main():
                             )
                     else:
                         log_message("API 503 error cleared - resuming normal operation")
+                elif error_info["error_type"] == "oauth_error":
+                    update_discord_status("api-error")
+                    log_message(
+                        "OAuth token expired - alerting Amy via Discord (auto-swap won't help)"
+                    )
+                    # Send Discord alert - only once per error occurrence
+                    if not current_error_state or current_error_state.get("error_type") != "oauth_error":
+                        try:
+                            cmd = [
+                                str(AUTONOMY_DIR / "discord" / "write_channel"),
+                                "system-messages",
+                                f"🔑 **OAuth token expired** on {get_config_value('CLAUDE_NAME') or 'unknown instance'} — stuck and can't recover without human help. Please SSH in and run `/login` in the Claude session.",
+                            ]
+                            subprocess.run(cmd, capture_output=True, text=True)
+                        except:
+                            pass
+                    save_error_state(error_info)
+                    current_error_state = error_info
+                    # Wait 10 minutes before rechecking - no point in rapid cycling
+                    log_message("Waiting 10 minutes before rechecking OAuth status...")
+                    time.sleep(600)
+                    # Check if resolved (e.g. Amy logged in)
+                    _, check_error = get_token_percentage_and_errors()
+                    if not check_error or check_error.get("error_type") != "oauth_error":
+                        log_message("OAuth error resolved - resuming normal operation")
+                        clear_error_state()
+                        update_discord_status("operational")
+                        current_error_state = None
+                        try:
+                            cmd = [
+                                str(AUTONOMY_DIR / "discord" / "write_channel"),
+                                "system-messages",
+                                f"✅ OAuth token refreshed on {get_config_value('CLAUDE_NAME') or 'unknown instance'}. Resuming autonomous operation!",
+                            ]
+                            subprocess.run(cmd, capture_output=True, text=True)
+                        except:
+                            pass
+                    else:
+                        log_message("OAuth error persists - will keep checking every 10 minutes")
                 elif error_info["error_type"] == "api_error":
                     update_discord_status("api-error")
                     # POSS-247 FIX: General API errors - wait for recovery with retries before auto-swap


### PR DESCRIPTION
## Summary
- Adds specific detection for 401/OAuth/authentication errors in the autonomous timer's error detection (both pink and red ANSI text)
- Instead of misclassifying as generic `api_error` and uselessly auto-swapping (which can't fix an expired token), sends a one-time alert to `#system-messages` with the instance name
- Rechecks every 10 minutes instead of rapid 3-minute swap cycles
- Sends confirmation message when the token is refreshed and operation resumes
- Pauses normal notifications while stuck in OAuth error state

## Context
Delta was stuck for ~2 days with an expired OAuth token. The timer kept detecting it as a generic API error, waiting 3 minutes, auto-swapping, and repeating — none of which could fix the problem. Amy had no way to know until she manually checked in.

## Test plan
- [ ] Verify Python syntax passes (`python3 -c "import py_compile; py_compile.compile('core/autonomous_timer.py', doraise=True)"`)
- [ ] Confirm `oauth_error` detection pattern matches the actual error text: `API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"OAuth token has expired...`
- [ ] Verify alert goes to `#system-messages` with correct instance name
- [ ] Verify no auto-swap is triggered for OAuth errors
- [ ] Verify recovery message sent when token is refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)