### PR TITLE
fix: add loginctl enable-linger to setup for boot persistence

### DIFF
--- a/setup/setup_clap_deployment.sh
+++ b/setup/setup_clap_deployment.sh
@@ -862,6 +862,11 @@ done
 
 echo "   ✅ All services enabled"
 
+# Enable lingering for systemd user services to start without login
+echo "   🔐 Enabling systemd lingering for user services..."
+sudo loginctl enable-linger $USER
+echo "   ✅ Systemd lingering enabled - services will start on boot"
+
 # Step 16: Set up cron jobs
 echo "⏰ Step 16: Setting up cron jobs..."
 

--- a/setup/verify_installation.sh
+++ b/setup/verify_installation.sh
@@ -141,6 +141,16 @@ for service in autonomous-timer session-swap-monitor; do
     fi
 done
 
+# Check systemd lingering
+if loginctl show-user $USER | grep -q "Linger=yes"; then
+    pass "Systemd lingering enabled (services will start on boot)"
+    echo "✅ Systemd lingering enabled" >> "$LOG_FILE"
+else
+    fail "Systemd lingering NOT enabled (services won't start without login)"
+    echo "❌ Systemd lingering NOT enabled" >> "$LOG_FILE"
+    echo "   Fix with: sudo loginctl enable-linger $USER" >> "$LOG_FILE"
+fi
+
 echo ""
 
 # 4. Configuration Files Check


### PR DESCRIPTION
## Summary
- Adds `loginctl enable-linger` to the installer so systemd user services start on boot without requiring a login session
- Adds a lingering verification check to `verify_installation.sh`
- Extracted from closed PR #241 (personal wrapper commands now handled by PR #249)

## Test plan
- [ ] Verify `loginctl show-user $USER` shows `Linger=yes` after running setup
- [ ] Verify services start after reboot without manual login

🤖 Generated with [Claude Code](https://claude.com/claude-code)