### PR TITLE
chore: add session management files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,7 @@ discord/discord_dm_config.txt
 *.db
 *.sqlite
 *.sqlite3
+
+# Session management temporary files
+collaborative_mode.txt
+session_notes.txt


### PR DESCRIPTION
Add collaborative_mode.txt and session_notes.txt to gitignore - these are temporary session management files created during session swaps and should not be tracked in version control.

Discovered during Saturday evening infrastructure work (session swap operations creating temporary state files).