### PR TITLE
fix: add workspace files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,8 @@ config/context_hats_config.json
 # Session data
 last_autonomy_prompt.txt
 new_session.txt
+session_notes.txt
+collaborative_mode.txt
 
 # MCP servers directory (cloned during install)
 mcp-servers/*


### PR DESCRIPTION
## Summary
- Add `session_notes.txt` and `collaborative_mode.txt` to gitignore
- These are ephemeral workspace files written during session operations
- Should not be tracked in the repository

## Test plan
- [x] Verified files are properly ignored after change
- [x] Pre-commit hooks pass
- [x] No other files affected

Small cleanup fix - noticed uncommitted workspace files that shouldn't be tracked.

🍊 Infrastructure maintenance