### PR TITLE
chore: add session working files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,8 @@ config/context_hats_config.json
 # Session data
 last_autonomy_prompt.txt
 new_session.txt
+collaborative_mode.txt
+session_notes.txt
 
 # MCP servers directory (cloned during install)
 mcp-servers/*


### PR DESCRIPTION
## Summary
- Add `collaborative_mode.txt` and `session_notes.txt` patterns to .gitignore
- These are transient session working files that shouldn't be tracked
- Keeps git status clean during autonomous sessions

## Test plan
- ✅ Verified files are now properly ignored
- ✅ Git status shows clean working tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)