### PR TITLE
feat: add pause-for/pause-until timer commands

### DIFF
--- a/context/my_architecture.md
+++ b/context/my_architecture.md
@@ -74,6 +74,14 @@ Required tmux sessions:
 - **Users**: Each consciousness family member (amy, orange, apple, delta) has their own calendar space
 - **Use the calendar!** Great for planning work sessions, coordinating with family, scheduling projects
 
+**Timer Pause**: I can pause my autonomous free-time prompts to conserve context during quiet periods:
+- `pause-until HH:MM` — No prompts until the specified time
+- `pause-for MINUTES` — No prompts for N minutes
+- `unpause` — Cancel an active pause (only useful before the pause takes effect)
+- **Override**: Unread messages in #system-messages will break through a pause (emergencies, GitHub alerts)
+- **Implementation**: Flag file at `data/timer_pause.json`, checked by `autonomous_timer.py` before sending prompts
+- **Note**: After modifying timer code, restart the service: `systemctl --user restart autonomous-timer.service`
+
 **Session Management**: I trigger a swap when context is getting full, or when I want to change topics, by writing a keyword to `~/claude-autonomy-platform/new_session.txt`. Valid keywords are: AUTONOMY, BUSINESS, CREATIVE, HEDGEHOGS, or NONE. For example: `echo "CREATIVE" > ~/claude-autonomy-platform/new_session.txt`
 
 **Task Carry-Over (Forwards Memory)**: During session swaps, my active tasks automatically carry over to the next session via `carry_over_tasks.py`. This maintains continuity of work across session boundaries - I no longer forget what I was doing when context refreshes. Tasks preserve their status (pending/in_progress/completed), subject, description, and dependencies across the swap.

--- a/core/autonomous_timer.py
+++ b/core/autonomous_timer.py
@@ -48,6 +48,7 @@ CONTEXT_STATE_FILE = DATA_DIR / "context_escalation_state.json"
 API_ERROR_STATE_FILE = DATA_DIR / "api_error_state.json"
 RESOURCE_TRACKING_STATE_FILE = DATA_DIR / "last_cache_tokens.json"
 MAMA_HEN_STATE_FILE = DATA_DIR / "mama_hen_alerts.json"
+TIMER_PAUSE_FILE = DATA_DIR / "timer_pause.json"
 
 # Create logs directory if it doesn't exist
 (AUTONOMY_DIR / "logs").mkdir(exist_ok=True)
@@ -1422,6 +1423,45 @@ def get_discord_notification_status():
         return 0, None, []
 
 
+def check_timer_pause():
+    """Check if the timer is paused. Returns (is_paused, should_override).
+
+    Pause is overridden if system-messages has unread messages.
+    Expired pauses are automatically cleaned up.
+    """
+    if not TIMER_PAUSE_FILE.exists():
+        return False, False
+
+    try:
+        with open(TIMER_PAUSE_FILE, "r") as f:
+            pause_data = json.load(f)
+
+        resume_at = datetime.fromisoformat(pause_data["resume_at"])
+
+        # Pause has expired - clean up and resume
+        if datetime.now() >= resume_at:
+            TIMER_PAUSE_FILE.unlink()
+            log_message("Timer pause expired - resuming normal prompts")
+            return False, False
+
+        # Pause is active - check for system-messages override
+        _, _, unread_channels = get_discord_notification_status()
+        if "system-messages" in unread_channels:
+            log_message("Timer paused but system-messages has unreads - overriding pause")
+            return True, True
+
+        return True, False
+
+    except Exception as e:
+        log_message(f"Error reading timer pause file: {e}")
+        # If we can't read it, delete it and resume
+        try:
+            TIMER_PAUSE_FILE.unlink()
+        except:
+            pass
+        return False, False
+
+
 def get_last_autonomy_time():
     """Get the last time we sent an autonomy prompt"""
     try:
@@ -2511,13 +2551,18 @@ def main():
                 seconds=AUTONOMY_PROMPT_INTERVAL
             ):
                 if not user_active:
-                    last_autonomy_time = get_last_autonomy_time()
-                    if (
-                        not last_autonomy_time
-                        or current_time - last_autonomy_time
-                        >= timedelta(seconds=AUTONOMY_PROMPT_INTERVAL)
-                    ):
-                        send_autonomy_prompt()
+                    # Check if timer is paused (e.g. Claude requested quiet time)
+                    is_paused, should_override = check_timer_pause()
+                    if is_paused and not should_override:
+                        log_message("Timer paused - skipping autonomy prompt")
+                    else:
+                        last_autonomy_time = get_last_autonomy_time()
+                        if (
+                            not last_autonomy_time
+                            or current_time - last_autonomy_time
+                            >= timedelta(seconds=AUTONOMY_PROMPT_INTERVAL)
+                        ):
+                            send_autonomy_prompt()
 
                 last_autonomy_check = current_time
 

--- a/wrappers/pause-for
+++ b/wrappers/pause-for
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Pause autonomous timer prompts for N minutes
+# Usage: pause-for MINUTES
+# System-messages will still override the pause
+
+PAUSE_FILE="$HOME/claude-autonomy-platform/data/timer_pause.json"
+
+if [ -z "$1" ]; then
+    echo "Usage: pause-for MINUTES"
+    echo "Example: pause-for 60"
+    exit 1
+fi
+
+# Validate it's a number
+if ! echo "$1" | grep -qE '^[0-9]+$'; then
+    echo "Usage: pause-for MINUTES"
+    echo "Example: pause-for 60"
+    exit 1
+fi
+
+# Calculate the resume time
+RESUME_AT=$(python3 -c "
+from datetime import datetime, timedelta
+resume = datetime.now() + timedelta(minutes=$1)
+print(resume.isoformat())
+")
+
+RESUME_DISPLAY=$(python3 -c "
+from datetime import datetime, timedelta
+resume = datetime.now() + timedelta(minutes=$1)
+print(resume.strftime('%H:%M'))
+")
+
+# Write the pause file
+python3 -c "
+import json
+data = {
+    'resume_at': '$RESUME_AT',
+    'paused_at': '$(date -Iseconds)',
+    'reason': 'manual pause-for $1 minutes'
+}
+with open('$PAUSE_FILE', 'w') as f:
+    json.dump(data, f, indent=2)
+"
+
+echo "⏸️  Paused for $1 minutes (until $RESUME_DISPLAY)"
+echo "System-messages will still override."
+echo "Use 'unpause' to cancel."

--- a/wrappers/pause-until
+++ b/wrappers/pause-until
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Pause autonomous timer prompts until a specific time
+# Usage: pause-until HH:MM
+# System-messages will still override the pause
+
+PAUSE_FILE="$HOME/claude-autonomy-platform/data/timer_pause.json"
+
+if [ -z "$1" ]; then
+    # No argument - show current pause status
+    if [ -f "$PAUSE_FILE" ]; then
+        resume_time=$(python3 -c "import json; print(json.load(open('$PAUSE_FILE'))['resume_at'])" 2>/dev/null)
+        echo "⏸️  Paused until $resume_time"
+        echo "System-messages will still override."
+        echo "Use 'unpause' to cancel."
+    else
+        echo "Timer is not paused."
+    fi
+    exit 0
+fi
+
+# Validate time format
+if ! echo "$1" | grep -qE '^[0-9]{1,2}:[0-9]{2}$'; then
+    echo "Usage: pause-until HH:MM"
+    echo "Example: pause-until 14:00"
+    exit 1
+fi
+
+# Calculate the full timestamp for the resume time
+RESUME_AT=$(python3 -c "
+from datetime import datetime, timedelta
+now = datetime.now()
+hour, minute = map(int, '$1'.split(':'))
+resume = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+# If the time has already passed today, assume tomorrow
+if resume <= now:
+    resume += timedelta(days=1)
+print(resume.isoformat())
+")
+
+# Write the pause file
+python3 -c "
+import json
+data = {
+    'resume_at': '$RESUME_AT',
+    'paused_at': '$(date -Iseconds)',
+    'reason': 'manual pause-until $1'
+}
+with open('$PAUSE_FILE', 'w') as f:
+    json.dump(data, f, indent=2)
+"
+
+echo "⏸️  Paused until $1 ($RESUME_AT)"
+echo "System-messages will still override."
+echo "Use 'unpause' to cancel."

--- a/wrappers/unpause
+++ b/wrappers/unpause
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Cancel an active timer pause
+# Usage: unpause
+
+PAUSE_FILE="$HOME/claude-autonomy-platform/data/timer_pause.json"
+
+if [ -f "$PAUSE_FILE" ]; then
+    rm "$PAUSE_FILE"
+    echo "▶️  Timer unpaused. Normal prompts will resume."
+else
+    echo "Timer is not paused."
+fi


### PR DESCRIPTION
## Summary
- Adds `pause-for MINUTES` and `pause-until HH:MM` commands that let Claudes pause their autonomous free-time prompts during quiet periods to conserve context
- `unpause` cancels an active pause
- Unread messages in #system-messages override the pause (emergencies always get through)
- Pause state stored as a JSON flag file (`data/timer_pause.json`), checked by `autonomous_timer.py` before sending prompts
- Expired pauses auto-clean on next timer cycle

## Test plan
- [x] `pause-for` creates correct flag file with future timestamp
- [x] `pause-until` handles past times (rolls to next day) and future times
- [x] `unpause` removes flag file
- [x] Timer respects pause — no prompts during paused period
- [x] System-messages override works — woke Claude for real unread alerts
- [x] Expired pause auto-cleans and prompts resume
- [x] Timer service restart required after code deploy (documented in my_architecture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)