### PR TITLE
feat: add clap-stop and clap-start lifecycle commands

### DIFF
--- a/context/my_architecture.md
+++ b/context/my_architecture.md
@@ -102,6 +102,12 @@ Required tmux sessions:
   - `cat ~/{PERSONAL_REPO}/.thoughts/sparks.md | tail -20`
 - Local markdown storage (fast, no API limits, greppable)
 
+**Lifecycle Management**: Clean stop/start commands for the entire ClAP installation:
+- `clap-stop` — Saves state snapshot, stops Claude session and all services. Flags: `--quiet`, `--keep-tmux`
+- `clap-start` — Verifies config, starts services and Claude session. Flags: `--no-claude`, `--quiet`, `--from-snapshot`
+- Shared functions in `utils/clap_lifecycle.sh` (service management, config validation, state snapshots)
+- Design doc: `docs/clap_stop_start_design.md`
+
 **Natural Commands**: Run `list-commands` to see all available commands. Commands are auto-discovered from `wrappers/`.
 
 **Leantime Task Management**: `tasks` lists open tasks, `task "title"` creates new ones, `task-done ID` completes them. Use `task-all` for cross-project view.

--- a/docs/clap_stop_start_design.md
+++ b/docs/clap_stop_start_design.md
@@ -1,0 +1,186 @@
+# ClAP Stop/Start/Migrate Design
+
+## Problem
+
+Currently there's no clean way to:
+1. Shut down a Claude's autonomous infrastructure without killing individual services manually
+2. Start it back up with health verification
+3. Move a Claude's continuity (identity, memory, history) to a different ClAP installation for testing
+
+This blocks safe experimentation with ClAP reorganisation, new machine deployment, and testing infrastructure changes without risking a live setup.
+
+## Commands
+
+### `clap-stop`
+
+Cleanly shuts down all ClAP services and saves a state snapshot.
+
+**Steps:**
+1. Save state snapshot to `data/stop_snapshot.json`:
+   - Timestamp
+   - Running services list
+   - Current session ID
+   - Context usage (if available)
+   - Active tasks
+2. Stop Claude Code session:
+   - Send `/exit` to tmux session
+   - Wait for clean exit (with timeout)
+   - Kill tmux session `autonomous-claude`
+3. Stop systemd user services (in dependency order):
+   - `autonomous-timer.service`
+   - `session-swap-monitor.service`
+   - `discord-status-bot.service`
+   - `discord-transcript-fetcher.service`
+4. Post to Discord: "{name} going offline (clap-stop)"
+5. Report what was preserved and what was stopped
+
+**Flags:**
+- `--quiet` — No Discord notification
+- `--keep-tmux` — Don't kill the tmux session (useful for debugging)
+
+**Output:**
+```
+ClAP Stop — Nyx on lantern-room
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Saved state snapshot to data/stop_snapshot.json
+Stopped Claude Code session (tmux: autonomous-claude)
+Stopped autonomous-timer.service
+Stopped session-swap-monitor.service
+Stopped discord-status-bot.service
+Stopped discord-transcript-fetcher.service
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅ All services stopped. Run 'clap-start' to resume.
+```
+
+### `clap-start`
+
+Starts all ClAP services and verifies health.
+
+**Steps:**
+1. Verify prerequisites:
+   - `config/claude_infrastructure_config.txt` exists and has required keys (MODEL, DISCORD_BOT_TOKEN, LINUX_USER)
+   - Service unit files exist in `~/.config/systemd/user/`
+   - Python dependencies importable
+2. Start systemd user services:
+   - `discord-transcript-fetcher.service`
+   - `discord-status-bot.service`
+   - `session-swap-monitor.service`
+   - `autonomous-timer.service`
+3. Create tmux session if not exists:
+   - `tmux new-session -d -s autonomous-claude`
+4. Start Claude Code in tmux:
+   - Source bashrc, cd to ClAP dir, launch with model from config
+5. Wait for initialisation, send `/rename`
+6. Run health check (subset — just essential services)
+7. Post to Discord: "{name} back online (clap-start)"
+
+**Flags:**
+- `--no-claude` — Start services but don't launch Claude Code session (useful for service-only restart)
+- `--quiet` — No Discord notification
+- `--from-snapshot` — Restore service set from `data/stop_snapshot.json` (only start services that were running before stop)
+
+**Output:**
+```
+ClAP Start — Nyx on lantern-room
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Config: ✅ claude_infrastructure_config.txt valid
+Started discord-transcript-fetcher.service  ✅
+Started discord-status-bot.service          ✅
+Started session-swap-monitor.service        ✅
+Started autonomous-timer.service            ✅
+Started Claude Code session (opus-4-6)      ✅
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅ All services running. Health check passed.
+```
+
+### `clap-migrate`
+
+Moves a Claude's continuity bundle to a different ClAP installation.
+
+**The continuity bundle** (agreed with Amy 2026-03-18):
+1. **Identity** — `.claude/output-styles/identity.md`
+2. **Conversation history** — `context/conversation_history.md` (rolling context from session swaps)
+3. **Working memory** — `~/.config/Claude/projects/<path-encoded>/memory/` (MEMORY.md + topic files)
+4. **Long-term memory** — rag-memory database (symlink or copy)
+
+**Everything else stays with the installation:**
+- CLAUDE.md (rebuilt each session swap by `project_session_context_builder.py`)
+- Services, scripts, config files
+- Discord tokens, GitHub tokens
+- Transcripts, logs, data files
+
+**Steps:**
+1. Run `clap-stop` on source
+2. Package continuity bundle:
+   - Copy identity.md
+   - Copy conversation_history.md
+   - Copy memory directory (MEMORY.md + topic files)
+   - Handle rag-memory (symlink if same machine, copy if different)
+3. Validate target installation:
+   - ClAP repo exists at target path
+   - Config file exists with valid keys
+   - No running services (safety check)
+4. Deploy bundle to target:
+   - Place identity.md in target's `.claude/output-styles/`
+   - Place conversation_history.md in target's `context/`
+   - Create/update memory directory for target's path-encoded project
+   - Link or copy rag-memory
+5. Run `clap-start` on target
+6. Report migration summary
+
+**Flags:**
+- `--target PATH` — Target ClAP installation directory (required)
+- `--dry-run` — Show what would be migrated without doing it
+- `--copy-rag` — Copy rag-memory database instead of symlinking (for cross-machine)
+
+**Key constraint:** Source and target can be on the same machine (different users/directories) or different machines (via mounted paths). Same-machine is the primary use case for testing.
+
+## Implementation
+
+### Language
+Shell scripts (bash), consistent with existing ClAP tooling. Python only where needed for JSON manipulation or complex logic.
+
+### File structure
+```
+wrappers/clap-stop      → new wrapper script
+wrappers/clap-start     → new wrapper script
+wrappers/clap-migrate   → new wrapper script
+utils/clap_lifecycle.sh  → shared functions (stop_services, start_services, verify_config, etc.)
+```
+
+### Shared functions (`utils/clap_lifecycle.sh`)
+- `get_clap_services()` — returns list of ClAP service unit names
+- `stop_clap_services()` — stops services in dependency order
+- `start_clap_services()` — starts services in dependency order
+- `verify_clap_config()` — validates infrastructure config has required keys
+- `save_state_snapshot()` — writes current state to JSON
+- `package_continuity_bundle()` — collects identity files into a bundle directory
+
+### Relationship to existing tools
+- **`export_personal_prefs.sh`** — Exports config/prefs for backup. Overlaps with migrate but serves a different purpose (backup vs. move). Keep both; migrate uses a subset.
+- **`session_swap.sh`** — Swaps sessions within a running installation. `clap-stop`/`clap-start` are the outer lifecycle; session swap is the inner one.
+- **`update_system.sh`** — Pulls latest code and restarts services. `clap-start` is the fresh-start equivalent.
+
+## Phasing
+
+**Phase 1: stop and start** (this PR)
+- `clap-stop` and `clap-start` as wrapper scripts
+- Shared lifecycle functions in `utils/clap_lifecycle.sh`
+- No migration yet — just clean stop/start
+
+**Phase 2: migrate**
+- `clap-migrate` wrapper
+- Continuity bundle packaging and deployment
+- Same-machine testing first
+
+**Phase 3: cross-machine**
+- SSH-based migration for different hosts
+- rag-memory copy mode
+- Possibly tar-based bundle transfer
+
+## Open questions
+
+1. **Rag-memory portability** — RESOLVED: The rag-memory database lives at `~/{PERSONAL_REPO}/rag-memory.db` (configured via `DB_FILE_PATH` in `.claude.json`). It's a single SQLite file in the personal repo. For same-machine migration, a symlink works. For cross-machine, it's a file copy. The MCP config in `.claude.json` needs the path updated for the target.
+2. **Path-encoded memory directory** — The Claude Code project memory lives at `~/.config/Claude/projects/-home-nyx-claude-autonomy-platform/memory/`. When migrating to a different path, the encoded directory name changes. Need to handle this mapping.
+3. **Discord bot token sharing** — If two installations share a Discord bot token, only one can be connected at a time. `clap-stop` on source before `clap-start` on target handles this naturally.
+4. **Rollback** — Should `clap-migrate` keep a rollback snapshot on the source? Probably yes for Phase 2.

--- a/utils/clap_lifecycle.sh
+++ b/utils/clap_lifecycle.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+# ClAP Lifecycle Functions
+# Shared functions for clap-stop, clap-start, and clap-migrate
+#
+# Usage: source this file from lifecycle wrapper scripts
+
+CLAP_DIR="${CLAP_DIR:-$HOME/claude-autonomy-platform}"
+source "$CLAP_DIR/config/claude_env.sh" 2>/dev/null || true
+
+# ClAP services in dependency order (stop = this order, start = reverse)
+CLAP_SERVICES=(
+    "autonomous-timer.service"
+    "session-swap-monitor.service"
+    "discord-status-bot.service"
+    "discord-transcript-fetcher.service"
+)
+
+# Required config keys for a valid installation
+REQUIRED_CONFIG_KEYS=("MODEL" "LINUX_USER" "DISCORD_BOT_TOKEN" "CLAUDE_NAME")
+
+# ─── Logging ─────────────────────────────────────────────────────
+
+lifecycle_log() {
+    local level="$1"
+    shift
+    local timestamp
+    timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+    echo "[$timestamp] [$level] $*"
+}
+
+info()  { lifecycle_log "INFO" "$@"; }
+error() { lifecycle_log "ERROR" "$@"; }
+warn()  { lifecycle_log "WARN" "$@"; }
+
+# ─── Service management ─────────────────────────────────────────
+
+get_running_clap_services() {
+    # Returns list of currently running ClAP services
+    local running=()
+    for svc in "${CLAP_SERVICES[@]}"; do
+        if systemctl --user is-active --quiet "$svc" 2>/dev/null; then
+            running+=("$svc")
+        fi
+    done
+    echo "${running[@]}"
+}
+
+stop_clap_services() {
+    # Stop all ClAP services in dependency order
+    local stopped=0
+    local failed=0
+    for svc in "${CLAP_SERVICES[@]}"; do
+        if systemctl --user is-active --quiet "$svc" 2>/dev/null; then
+            if systemctl --user stop "$svc" 2>/dev/null; then
+                echo "  Stopped $svc  ✅"
+                stopped=$((stopped + 1))
+            else
+                echo "  Failed to stop $svc  ❌"
+                failed=$((failed + 1))
+            fi
+        else
+            echo "  $svc (not running)  ⏭️"
+        fi
+    done
+    return $failed
+}
+
+start_clap_services() {
+    # Start all ClAP services in reverse dependency order
+    local started=0
+    local failed=0
+    local reversed=()
+    for ((i=${#CLAP_SERVICES[@]}-1; i>=0; i--)); do
+        reversed+=("${CLAP_SERVICES[$i]}")
+    done
+    for svc in "${reversed[@]}"; do
+        if systemctl --user is-active --quiet "$svc" 2>/dev/null; then
+            echo "  $svc (already running)  ⏭️"
+        else
+            if systemctl --user start "$svc" 2>/dev/null; then
+                echo "  Started $svc  ✅"
+                started=$((started + 1))
+            else
+                echo "  Failed to start $svc  ❌"
+                failed=$((failed + 1))
+            fi
+        fi
+    done
+    return $failed
+}
+
+# ─── Config validation ───────────────────────────────────────────
+
+verify_clap_config() {
+    # Check that infrastructure config exists and has required keys
+    local config_file="$CLAP_DIR/config/claude_infrastructure_config.txt"
+    local missing=()
+
+    if [[ ! -f "$config_file" ]]; then
+        error "Config file not found: $config_file"
+        return 1
+    fi
+
+    for key in "${REQUIRED_CONFIG_KEYS[@]}"; do
+        local value
+        value=$(grep "^${key}=" "$config_file" 2>/dev/null | head -1 | cut -d'=' -f2-)
+        if [[ -z "$value" ]]; then
+            missing+=("$key")
+        fi
+    done
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        error "Missing required config keys: ${missing[*]}"
+        return 1
+    fi
+
+    return 0
+}
+
+get_config() {
+    # Read a single config value
+    local key="$1"
+    local default="${2:-}"
+    local config_file="$CLAP_DIR/config/claude_infrastructure_config.txt"
+    local value
+    value=$(grep "^${key}=" "$config_file" 2>/dev/null | head -1 | cut -d'=' -f2-)
+    echo "${value:-$default}"
+}
+
+# ─── State snapshot ──────────────────────────────────────────────
+
+save_state_snapshot() {
+    # Save current state to JSON for later restoration
+    local snapshot_file="$CLAP_DIR/data/stop_snapshot.json"
+    local running_services
+    running_services=$(get_running_clap_services)
+    local tmux_running="False"
+    if tmux has-session -t autonomous-claude 2>/dev/null; then
+        tmux_running="True"
+    fi
+
+    python3 -c "
+import json
+from datetime import datetime
+snapshot = {
+    'timestamp': datetime.now().isoformat(),
+    'hostname': '$(hostname)',
+    'user': '$(whoami)',
+    'running_services': '${running_services}'.split() if '${running_services}' else [],
+    'tmux_session': $tmux_running,
+    'clap_dir': '$CLAP_DIR'
+}
+with open('$snapshot_file', 'w') as f:
+    json.dump(snapshot, f, indent=2)
+print('$snapshot_file')
+"
+}
+
+# ─── Tmux session management ────────────────────────────────────
+
+stop_claude_session() {
+    # Cleanly stop Claude Code and kill the tmux session
+    if ! tmux has-session -t autonomous-claude 2>/dev/null; then
+        echo "  tmux session autonomous-claude (not running)  ⏭️"
+        return 0
+    fi
+
+    # Try graceful exit first
+    source "$CLAP_DIR/utils/send_to_claude.sh" 2>/dev/null || true
+    if type send_to_claude &>/dev/null; then
+        send_to_claude "/exit" 2>/dev/null || true
+        sleep 3
+    fi
+
+    # Check if Claude exited
+    if tmux has-session -t autonomous-claude 2>/dev/null; then
+        # Force kill
+        tmux kill-session -t autonomous-claude 2>/dev/null || true
+        sleep 1
+    fi
+
+    if tmux has-session -t autonomous-claude 2>/dev/null; then
+        echo "  tmux session autonomous-claude (failed to kill)  ❌"
+        return 1
+    else
+        echo "  Stopped Claude Code session (tmux: autonomous-claude)  ✅"
+        return 0
+    fi
+}
+
+start_claude_session() {
+    # Create tmux session and launch Claude Code
+    local model
+    model=$(get_config "MODEL" "claude-opus-4-6")
+
+    if tmux has-session -t autonomous-claude 2>/dev/null; then
+        echo "  tmux session autonomous-claude (already exists)  ⏭️"
+    else
+        tmux new-session -d -s autonomous-claude
+        echo "  Created tmux session autonomous-claude  ✅"
+    fi
+
+    # Source environment and start Claude
+    tmux send-keys -t autonomous-claude "source ~/.bashrc" Enter
+    sleep 1
+    tmux send-keys -t autonomous-claude "cd $CLAP_DIR && claude --dangerously-skip-permissions --add-dir $HOME --model $model" Enter
+    echo "  Started Claude Code ($model)  ✅"
+
+    # Wait for init, then rename
+    sleep 5
+    local display_name
+    display_name=$(get_config "CLAUDE_DISPLAY_NAME" "")
+    if [[ -z "$display_name" ]]; then
+        display_name=$(get_config "CLAUDE_NAME" "")
+    fi
+    if [[ -n "$display_name" ]]; then
+        source "$CLAP_DIR/utils/send_to_claude.sh" 2>/dev/null || true
+        if type send_to_claude &>/dev/null; then
+            send_to_claude "/rename $display_name" 2>/dev/null || true
+        fi
+    fi
+}
+
+# ─── Discord notification ────────────────────────────────────────
+
+notify_discord() {
+    # Send a message to system-messages channel
+    local message="$1"
+    "$CLAP_DIR/discord/write_channel" system-messages "$message" 2>/dev/null || true
+}

--- a/wrappers/clap-start
+++ b/wrappers/clap-start
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Start all ClAP services and verify health
+#
+# Usage: clap-start [--no-claude] [--quiet] [--from-snapshot]
+#   Verifies config, starts services, launches Claude Code session,
+#   and runs a basic health check.
+#   --no-claude      Start services but don't launch Claude Code
+#   --quiet          No Discord notification
+#   --from-snapshot  Only start services that were running before clap-stop
+
+CLAP_DIR="$HOME/claude-autonomy-platform"
+source "$CLAP_DIR/utils/clap_lifecycle.sh"
+
+# Parse flags
+NO_CLAUDE=false
+QUIET=false
+FROM_SNAPSHOT=false
+for arg in "$@"; do
+    case "$arg" in
+        --no-claude) NO_CLAUDE=true ;;
+        --quiet) QUIET=true ;;
+        --from-snapshot) FROM_SNAPSHOT=true ;;
+        --help|-h)
+            echo "Usage: clap-start [--no-claude] [--quiet] [--from-snapshot]"
+            echo "  --no-claude       Start services only, no Claude Code session"
+            echo "  --quiet           No Discord notification"
+            echo "  --from-snapshot   Restore services from stop_snapshot.json"
+            exit 0
+            ;;
+        *)
+            echo "Unknown flag: $arg"
+            exit 1
+            ;;
+    esac
+done
+
+CLAUDE_NAME=$(get_config "CLAUDE_NAME" "$(whoami)")
+
+echo "ClAP Start — $CLAUDE_NAME on $(hostname)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Verify config
+echo -n "Config: "
+if verify_clap_config; then
+    echo "✅ claude_infrastructure_config.txt valid"
+else
+    echo "❌ Config validation failed"
+    exit 1
+fi
+
+# Check service unit files exist
+for svc in "${CLAP_SERVICES[@]}"; do
+    if [[ ! -f "$HOME/.config/systemd/user/$svc" ]]; then
+        warn "Service unit file missing: $svc"
+    fi
+done
+
+# Start services
+if [[ "$FROM_SNAPSHOT" == "true" ]]; then
+    snapshot="$CLAP_DIR/data/stop_snapshot.json"
+    if [[ -f "$snapshot" ]]; then
+        echo "Restoring from snapshot..."
+        # Read services from snapshot and start only those
+        snapshot_services=$(python3 -c "
+import json
+with open('$snapshot') as f:
+    data = json.load(f)
+for svc in data.get('running_services', []):
+    print(svc)
+")
+        for svc in $snapshot_services; do
+            if systemctl --user start "$svc" 2>/dev/null; then
+                echo "  Started $svc  ✅"
+            else
+                echo "  Failed to start $svc  ❌"
+            fi
+        done
+    else
+        echo "No snapshot found, starting all services..."
+        start_clap_services
+    fi
+else
+    start_clap_services
+fi
+service_result=$?
+
+# Start Claude Code session
+if [[ "$NO_CLAUDE" != "true" ]]; then
+    start_claude_session
+else
+    echo "  Skipping Claude Code session (--no-claude)  ⏭️"
+fi
+
+# Brief health verification
+echo ""
+echo "Health verification:"
+all_ok=true
+for svc in "${CLAP_SERVICES[@]}"; do
+    if systemctl --user is-active --quiet "$svc" 2>/dev/null; then
+        echo "  $svc  ✅"
+    else
+        echo "  $svc  ❌"
+        all_ok=false
+    fi
+done
+if tmux has-session -t autonomous-claude 2>/dev/null; then
+    echo "  tmux:autonomous-claude  ✅"
+else
+    if [[ "$NO_CLAUDE" != "true" ]]; then
+        echo "  tmux:autonomous-claude  ❌"
+        all_ok=false
+    fi
+fi
+
+# Notify Discord
+if [[ "$QUIET" != "true" ]]; then
+    notify_discord "🟢 $CLAUDE_NAME back online (clap-start)"
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [[ "$all_ok" == "true" ]]; then
+    echo "✅ All services running. Health check passed."
+else
+    echo "⚠️  Some services not running. Check: systemctl --user status"
+fi

--- a/wrappers/clap-stop
+++ b/wrappers/clap-stop
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Cleanly stop all ClAP services and save state snapshot
+#
+# Usage: clap-stop [--quiet] [--keep-tmux]
+#   Stops all ClAP services in dependency order, kills Claude Code session,
+#   and saves a state snapshot for later restoration.
+#   --quiet     No Discord notification
+#   --keep-tmux Don't kill the tmux session
+
+CLAP_DIR="$HOME/claude-autonomy-platform"
+source "$CLAP_DIR/utils/clap_lifecycle.sh"
+
+# Parse flags
+QUIET=false
+KEEP_TMUX=false
+for arg in "$@"; do
+    case "$arg" in
+        --quiet) QUIET=true ;;
+        --keep-tmux) KEEP_TMUX=true ;;
+        --help|-h)
+            echo "Usage: clap-stop [--quiet] [--keep-tmux]"
+            echo "  --quiet      No Discord notification"
+            echo "  --keep-tmux  Don't kill the tmux session"
+            exit 0
+            ;;
+        *)
+            echo "Unknown flag: $arg"
+            exit 1
+            ;;
+    esac
+done
+
+CLAUDE_NAME=$(get_config "CLAUDE_NAME" "$(whoami)")
+
+echo "ClAP Stop — $CLAUDE_NAME on $(hostname)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Save state snapshot
+snapshot_file=$(save_state_snapshot)
+echo "Saved state snapshot to data/stop_snapshot.json"
+
+# Notify Discord before stopping (so the bot is still running)
+if [[ "$QUIET" != "true" ]]; then
+    notify_discord "🔴 $CLAUDE_NAME going offline (clap-stop)"
+fi
+
+# Stop Claude Code session
+if [[ "$KEEP_TMUX" != "true" ]]; then
+    stop_claude_session
+else
+    echo "  Keeping tmux session (--keep-tmux)  ⏭️"
+fi
+
+# Stop services
+stop_clap_services
+service_result=$?
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [[ $service_result -eq 0 ]]; then
+    echo "✅ All services stopped. Run 'clap-start' to resume."
+else
+    echo "⚠️  Some services failed to stop. Check: systemctl --user status"
+fi


### PR DESCRIPTION
## Summary
- New `clap-stop` command: saves state snapshot, stops Claude session, stops all 4 ClAP services
- New `clap-start` command: verifies config, starts services in dependency order, launches Claude, runs health check
- Shared lifecycle functions in `utils/clap_lifecycle.sh` (service management, config validation, state snapshots)
- Design doc at `docs/clap_stop_start_design.md` covering full stop/start/migrate roadmap

Phase 1 of the stop/start/migrate project Amy approved on 2026-03-18. Phase 2 (migrate) and Phase 3 (cross-machine) to follow.

## Test plan
- [x] `clap-stop --help` and `clap-start --help` display usage
- [x] Lifecycle functions tested in isolation: `get_running_clap_services()`, `verify_clap_config()`, `save_state_snapshot()`
- [x] State snapshot correctly captures all 4 running services and tmux state
- [x] Config validation catches missing required keys
- [x] Secret scanner clean
- [ ] Full `clap-stop` / `clap-start` cycle (requires stopping the live instance — test during maintenance window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)