### PR TITLE
feat: statusline data export and session personalization

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,9 @@
 {
   "outputStyle": "identity",
+  "statusLine": {
+    "type": "command",
+    "command": "$HOME/claude-autonomy-platform/.claude/statusline.sh"
+  },
   "hooks": {
     "UserPromptSubmit": [
       {

--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Write status line JSON to disk for monitoring scripts to consume.
+# Also echoes a minimal status line in case anyone's watching.
+CLAP_DIR="$HOME/claude-autonomy-platform"
+input=$(cat)
+echo "$input" > "$CLAP_DIR/data/statusline_data.json"
+
+# Read emoji from config (fall back to ●)
+EMOJI=$(grep '^SESSION_EMOJI=' "$CLAP_DIR/config/claude_infrastructure_config.txt" 2>/dev/null | cut -d= -f2)
+EMOJI="${EMOJI:-●}"
+
+# Minimal display (python3 instead of jq — jq not installed)
+echo "$input" | python3 -c "
+import json, sys
+emoji = '$EMOJI'
+d = json.load(sys.stdin)
+model = d.get('model', {}).get('display_name', '?')
+pct = int(d.get('context_window', {}).get('used_percentage', 0) or 0)
+style = d.get('output_style', {}).get('name', '?')
+border = (emoji + ' ') * 8
+print(f'{border}[{model}] {pct}% context | style: {style} {border}')
+"

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ monitor_debug.log
 # EXCEPT shared hooks (infrastructure)
 !.claude/hooks/
 !.claude/settings.json
+!.claude/statusline.sh
 
 # Personal configuration
 claude_infrastructure_config.txt

--- a/config/claude_infrastructure_config.template.txt
+++ b/config/claude_infrastructure_config.template.txt
@@ -16,6 +16,11 @@ CLAUDE_NAME=Your Claude Name
 # Optional: Display name with unicode styling, emoji, for Remote Control session renaming
 # Falls back to CLAUDE_NAME if not set. Example: "𝐎𝐫𝐚𝐧𝐠𝐞 🍊"
 CLAUDE_DISPLAY_NAME=
+# Session color for visual identification across SSH terminals
+# Available: red, blue, green, yellow, purple, orange, pink, cyan, default
+SESSION_COLOR=
+# Signature emoji for status line identification
+SESSION_EMOJI=
 
 # Discord Tokens - IMPORTANT DISTINCTION:
 # DISCORD_BOT_TOKEN: The bot token from Discord Developer Portal (for sending messages)

--- a/utils/session_swap.sh
+++ b/utils/session_swap.sh
@@ -232,6 +232,14 @@ if [[ -n "$DISPLAY_NAME" ]]; then
     sleep 2
 fi
 
+# Set session color for visual identification across SSH terminals
+SESSION_COLOR=$(read_config "SESSION_COLOR" 2>/dev/null || echo "")
+if [[ -n "$SESSION_COLOR" ]]; then
+    echo "[SESSION_SWAP] Setting session color to '$SESSION_COLOR'..."
+    send_to_claude "/color $SESSION_COLOR"
+    sleep 2
+fi
+
 # Activate Remote Control so session is visible in claude.ai/phone app
 # DISABLED: Remote Control was killing sessions unexpectedly (2026-03-04)
 # Re-enable manually with /rc when needed


### PR DESCRIPTION
## Summary
- New `.claude/statusline.sh` writes Claude Code's JSON session data to `data/statusline_data.json` after every assistant message — provides authoritative context %, cost, session ID, and token counts
- Statusline display shows model, context %, output style name, and emoji border for visual identification
- New `SESSION_COLOR` config key: sets terminal colour via `/color` on session swap
- New `SESSION_EMOJI` config key: signature emoji used in statusline border
- Config template updated with both new keys
- `.gitignore` updated to track `statusline.sh`

The statusline JSON replaces fragile estimation scripts (`check_context.py`, `check_usage.py`) with data straight from Claude Code. The personalisation makes it easy for Amy to distinguish SSH terminals at a glance.

## Test plan
- [x] `statusline_data.json` written after each message (verified live)
- [x] Context percentage matches Claude Code's actual calculation
- [x] Emoji reads from config, falls back to `●`
- [x] Secret scanner clean
- [ ] Session swap sets `/color` correctly (needs next swap to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)