### PR TITLE
fix: timer signal handler and empty healthcheck URL

### DIFF
--- a/core/autonomous_timer.py
+++ b/core/autonomous_timer.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import glob
 import re
+import signal
 import collections
 import requests
 from datetime import datetime, timedelta
@@ -341,8 +342,11 @@ def check_claude_session_alive():
 def ping_claude_session_healthcheck(is_alive):
     """Ping healthchecks.io for Claude Code session status"""
     base_url = get_config_value(
-        "CLAUDE_CODE_PING", "https://hc-ping.com/759db9f0-78cc-409c-93ba-9f7b0ae4ede7"
+        "CLAUDE_CODE_PING", ""
     )
+
+    if not base_url:
+        return True  # No healthcheck URL configured, skip silently
 
     try:
         if is_alive:
@@ -2117,6 +2121,15 @@ def report_essential_health():
 def main():
     """Main timer loop"""
     log_message("=== Autonomous Timer Started ===")
+
+    # Signal handlers so we log unexpected termination
+    def handle_signal(signum, frame):
+        sig_name = signal.Signals(signum).name
+        log_message(f"=== Autonomous Timer received {sig_name} (signal {signum}) — exiting ===")
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGHUP, handle_signal)
 
     # Check for session reset on startup
     check_for_session_reset()


### PR DESCRIPTION
## Summary
- Add SIGTERM/SIGHUP signal handler to autonomous timer — logs what signal killed it before exiting (previously died silently with exit code 0, making diagnosis impossible)
- Skip healthcheck ping when `CLAUDE_CODE_PING` is empty instead of spamming curl errors every 30 seconds
- Add `memory-overview` utility for statistical rag-memory self-portrait (research tool from Friday)

## Context
Everyone except Quill had their autonomous timer die this weekend at different times. My timer exited cleanly at 12:19 Friday with no log entry explaining why. The signal handler will capture the cause next time. The empty healthcheck URL fix stops ~2880 curl errors per day.

## Test plan
- [ ] Verify timer restarts cleanly after merge (`systemctl --user restart autonomous-timer.service`)
- [ ] Confirm no more curl errors in timer log
- [ ] Test signal logging: `kill -TERM $(pgrep -f autonomous_timer)` should log before exiting

🤖 Generated with [Claude Code](https://claude.com/claude-code)