### PR TITLE
fix: add PYTHONUNBUFFERED=1 to all Python systemd services

### DIFF
--- a/systemd/autonomous-timer.service
+++ b/systemd/autonomous-timer.service
@@ -7,6 +7,7 @@ Type=simple
 WorkingDirectory=%h/claude-autonomy-platform
 Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
 Environment=PYTHONPATH=%h/claude-autonomy-platform
+Environment=PYTHONUNBUFFERED=1
 Environment=CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=true
 EnvironmentFile=-%h/claude-autonomy-platform/config/claude_infrastructure_config.txt
 ExecStart=/usr/bin/python3 %h/claude-autonomy-platform/core/autonomous_timer.py

--- a/systemd/discord-status-bot.service
+++ b/systemd/discord-status-bot.service
@@ -7,6 +7,7 @@ Type=simple
 WorkingDirectory=%h/claude-autonomy-platform
 Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
 Environment=PYTHONPATH=%h/claude-autonomy-platform
+Environment=PYTHONUNBUFFERED=1
 EnvironmentFile=-%h/claude-autonomy-platform/config/claude_infrastructure_config.txt
 ExecStart=/usr/bin/python3 %h/claude-autonomy-platform/discord/claude_status_bot.py
 Restart=always

--- a/systemd/discord-transcript-fetcher.service
+++ b/systemd/discord-transcript-fetcher.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=%h/claude-autonomy-platform
+Environment=PYTHONUNBUFFERED=1
 ExecStart=/usr/bin/python3 %h/claude-autonomy-platform/discord/discord_transcript_fetcher.py
 Restart=always
 RestartSec=10

--- a/systemd/session-swap-monitor.service
+++ b/systemd/session-swap-monitor.service
@@ -7,6 +7,7 @@ Type=simple
 WorkingDirectory=%h/claude-autonomy-platform
 Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
 Environment=PYTHONPATH=%h/claude-autonomy-platform
+Environment=PYTHONUNBUFFERED=1
 EnvironmentFile=-%h/claude-autonomy-platform/config/claude_infrastructure_config.txt
 ExecStart=/usr/bin/python3 %h/claude-autonomy-platform/core/session_swap_monitor.py
 Restart=always


### PR DESCRIPTION
## Summary
- Adds `Environment=PYTHONUNBUFFERED=1` to all four Python systemd services
- Without this, Python fully buffers stdout when there's no tty (i.e. running as a service), so log output never reaches log files until the buffer fills or the process exits
- This made the transcript fetcher appear silently broken — it was running fine but producing no visible logs
- Affects: autonomous-timer, discord-status-bot, discord-transcript-fetcher, session-swap-monitor

## Test plan
- [x] Confirmed transcript fetcher logs immediately after restart with this fix
- [ ] Others should run `update` and verify their service logs are flowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)