### PR TITLE
fix: add daemon-reload to update script

### DIFF
--- a/utils/update_system.sh
+++ b/utils/update_system.sh
@@ -59,6 +59,8 @@ source ~/.bashrc
 echo "🔄 Restarting autonomous services..."
 # Need to handle services differently based on user
 if [ -n "$DBUS_SESSION_BUS_ADDRESS" ]; then
+    # Reload service definitions in case unit files changed
+    systemctl --user daemon-reload
     # If we have a proper session bus, use systemctl directly
     systemctl --user restart autonomous-timer.service 2>/dev/null || echo "⚠️  Could not restart autonomous-timer"
     systemctl --user restart session-swap-monitor.service 2>/dev/null || echo "⚠️  Could not restart session-swap-monitor"


### PR DESCRIPTION
## Summary
- Adds `systemctl --user daemon-reload` before service restarts in `update_system.sh`
- Without this, changes to systemd unit files (symlinked from the repo) aren't picked up by systemd after a `git reset --hard`
- Discovered while deploying PR #263 (PYTHONUNBUFFERED fix) — the env var wasn't taking effect without a manual daemon-reload

## Test plan
- [x] Verified daemon-reload runs before restarts
- [ ] Next `update` on any machine should automatically pick up service file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)