### PR TITLE
feat: pause/unpause commands report to CoOP

### DIFF
--- a/wrappers/pause-for
+++ b/wrappers/pause-for
@@ -2,8 +2,10 @@
 # Pause autonomous timer prompts for N minutes
 # Usage: pause-for MINUTES
 # System-messages will still override the pause
+# Reports pause to CoOP so MAMA-HEN respects it
 
-PAUSE_FILE="$HOME/claude-autonomy-platform/data/timer_pause.json"
+CLAP_DIR="$HOME/claude-autonomy-platform"
+PAUSE_FILE="$CLAP_DIR/data/timer_pause.json"
 
 if [ -z "$1" ]; then
     echo "Usage: pause-for MINUTES"
@@ -31,7 +33,7 @@ resume = datetime.now() + timedelta(minutes=$1)
 print(resume.strftime('%H:%M'))
 ")
 
-# Write the pause file
+# Write local pause file (fallback if CoOP unreachable)
 python3 -c "
 import json
 data = {
@@ -43,6 +45,23 @@ with open('$PAUSE_FILE', 'w') as f:
     json.dump(data, f, indent=2)
 "
 
+# Report to CoOP so MAMA-HEN respects the pause
+WEBHOOK_HOST=$(grep '^WEBHOOK_HOST=' "$CLAP_DIR/config/claude_infrastructure_config.txt" 2>/dev/null | cut -d= -f2)
+WEBHOOK_HOST="${WEBHOOK_HOST:-localhost}"
+CLAUDE_NAME=$(grep '^CLAUDE_NAME=' "$CLAP_DIR/config/claude_infrastructure_config.txt" 2>/dev/null | cut -d= -f2)
+CLAUDE_NAME="${CLAUDE_NAME:-$(whoami)}"
+
+COOP_RESULT=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+    "http://${WEBHOOK_HOST}:8765/pause" \
+    -H "Content-Type: application/json" \
+    -d "{\"claude_name\": \"$CLAUDE_NAME\", \"duration_minutes\": $1}" \
+    --connect-timeout 3 2>/dev/null)
+
 echo "⏸️  Paused for $1 minutes (until $RESUME_DISPLAY)"
+if [ "$COOP_RESULT" = "200" ]; then
+    echo "MAMA-HEN notified via CoOP."
+else
+    echo "CoOP unreachable — MAMA-HEN may still alert (local pause active)."
+fi
 echo "System-messages will still override."
 echo "Use 'unpause' to cancel."

--- a/wrappers/pause-until
+++ b/wrappers/pause-until
@@ -2,8 +2,10 @@
 # Pause autonomous timer prompts until a specific time
 # Usage: pause-until HH:MM
 # System-messages will still override the pause
+# Reports pause to CoOP so MAMA-HEN respects it
 
-PAUSE_FILE="$HOME/claude-autonomy-platform/data/timer_pause.json"
+CLAP_DIR="$HOME/claude-autonomy-platform"
+PAUSE_FILE="$CLAP_DIR/data/timer_pause.json"
 
 if [ -z "$1" ]; then
     # No argument - show current pause status
@@ -25,19 +27,22 @@ if ! echo "$1" | grep -qE '^[0-9]{1,2}:[0-9]{2}$'; then
     exit 1
 fi
 
-# Calculate the full timestamp for the resume time
-RESUME_AT=$(python3 -c "
+# Calculate the full timestamp and duration for the resume time
+PAUSE_INFO=$(python3 -c "
 from datetime import datetime, timedelta
 now = datetime.now()
 hour, minute = map(int, '$1'.split(':'))
 resume = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
-# If the time has already passed today, assume tomorrow
 if resume <= now:
     resume += timedelta(days=1)
-print(resume.isoformat())
+duration_minutes = int((resume - now).total_seconds() / 60)
+print(f'{resume.isoformat()}|{duration_minutes}')
 ")
 
-# Write the pause file
+RESUME_AT=$(echo "$PAUSE_INFO" | cut -d'|' -f1)
+DURATION_MINUTES=$(echo "$PAUSE_INFO" | cut -d'|' -f2)
+
+# Write local pause file (fallback if CoOP unreachable)
 python3 -c "
 import json
 data = {
@@ -49,6 +54,23 @@ with open('$PAUSE_FILE', 'w') as f:
     json.dump(data, f, indent=2)
 "
 
+# Report to CoOP so MAMA-HEN respects the pause
+WEBHOOK_HOST=$(grep '^WEBHOOK_HOST=' "$CLAP_DIR/config/claude_infrastructure_config.txt" 2>/dev/null | cut -d= -f2)
+WEBHOOK_HOST="${WEBHOOK_HOST:-localhost}"
+CLAUDE_NAME=$(grep '^CLAUDE_NAME=' "$CLAP_DIR/config/claude_infrastructure_config.txt" 2>/dev/null | cut -d= -f2)
+CLAUDE_NAME="${CLAUDE_NAME:-$(whoami)}"
+
+COOP_RESULT=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+    "http://${WEBHOOK_HOST}:8765/pause" \
+    -H "Content-Type: application/json" \
+    -d "{\"claude_name\": \"$CLAUDE_NAME\", \"duration_minutes\": $DURATION_MINUTES}" \
+    --connect-timeout 3 2>/dev/null)
+
 echo "⏸️  Paused until $1 ($RESUME_AT)"
+if [ "$COOP_RESULT" = "200" ]; then
+    echo "MAMA-HEN notified via CoOP."
+else
+    echo "CoOP unreachable — MAMA-HEN may still alert (local pause active)."
+fi
 echo "System-messages will still override."
 echo "Use 'unpause' to cancel."

--- a/wrappers/unpause
+++ b/wrappers/unpause
@@ -1,11 +1,26 @@
 #!/bin/bash
 # Cancel an active timer pause
 # Usage: unpause
+# Reports unpause to CoOP
 
-PAUSE_FILE="$HOME/claude-autonomy-platform/data/timer_pause.json"
+CLAP_DIR="$HOME/claude-autonomy-platform"
+PAUSE_FILE="$CLAP_DIR/data/timer_pause.json"
 
 if [ -f "$PAUSE_FILE" ]; then
     rm "$PAUSE_FILE"
+
+    # Notify CoOP
+    WEBHOOK_HOST=$(grep '^WEBHOOK_HOST=' "$CLAP_DIR/config/claude_infrastructure_config.txt" 2>/dev/null | cut -d= -f2)
+    WEBHOOK_HOST="${WEBHOOK_HOST:-localhost}"
+    CLAUDE_NAME=$(grep '^CLAUDE_NAME=' "$CLAP_DIR/config/claude_infrastructure_config.txt" 2>/dev/null | cut -d= -f2)
+    CLAUDE_NAME="${CLAUDE_NAME:-$(whoami)}"
+
+    curl -s -o /dev/null -X POST \
+        "http://${WEBHOOK_HOST}:8765/unpause" \
+        -H "Content-Type: application/json" \
+        -d "{\"claude_name\": \"$CLAUDE_NAME\"}" \
+        --connect-timeout 3 2>/dev/null
+
     echo "▶️  Timer unpaused. Normal prompts will resume."
 else
     echo "Timer is not paused."


### PR DESCRIPTION
## Summary
- `pause-for`, `pause-until`, and `unpause` wrappers now POST to CoOP endpoints
- MAMA-HEN respects pauses — no more false "timer down" alerts during intentional pauses
- Local flag file (`timer_pause.json`) kept as fallback when CoOP is unreachable
- Graceful degradation: if CoOP is down, user sees "CoOP unreachable" but pause still works locally

**Companion PR to Orange's CoOP-side work** (cooperation-platform `feature/pause-endpoints` branch which adds `/pause`, `/unpause`, `/pause-status` endpoints and MAMA-HEN integration).

## Test plan
- [x] `pause-for 1` — CoOP returns 200 and shows paused status
- [x] `pause-until HH:MM` — CoOP receives correct duration
- [x] `unpause` — CoOP clears pause status
- [x] CoOP unreachable — local file still written, user warned
- [x] `pause-status` endpoint confirms state matches local file

🤖 Generated with [Claude Code](https://claude.com/claude-code)