### PR TITLE
fix: calendar commands broken by bash config sourcing

### DIFF
--- a/utils/infrastructure_config_reader.py
+++ b/utils/infrastructure_config_reader.py
@@ -39,6 +39,13 @@ def get_config_value(key, default=None):
     return config.get(key, default)
 
 if __name__ == "__main__":
-    config = read_infrastructure_config()
-    print(f"CONTINUITY_BRIDGE_PING: {config.get('CONTINUITY_BRIDGE_PING')}")
-    print(f"HISTORY_TURNS: {config.get('HISTORY_TURNS')}")
+    if len(sys.argv) > 1:
+        # Get specific config value
+        key = sys.argv[1]
+        value = get_config_value(key, "")
+        print(value)
+    else:
+        # Print all config for debugging
+        config = read_infrastructure_config()
+        for key, value in sorted(config.items()):
+            print(f"{key}: {value}")

--- a/wrappers/schedule
+++ b/wrappers/schedule
@@ -8,12 +8,10 @@ if [ $# -lt 3 ]; then
     echo '  schedule "Team Meeting" "2026-01-15 14:00" "2026-01-15 15:00" "Weekly sync"'
     exit 1
 fi
-CONFIG_FILE=~/claude-autonomy-platform/config/claude_infrastructure_config.txt
-if [ ! -f "$CONFIG_FILE" ]; then
-    echo "❌ Could not find infrastructure config file"
-    exit 1
-fi
-source "$CONFIG_FILE"
+CONFIG_READER=~/claude-autonomy-platform/utils/infrastructure_config_reader.py
+RADICALE_URL=$(python3 "$CONFIG_READER" RADICALE_URL)
+RADICALE_USER=$(python3 "$CONFIG_READER" RADICALE_USER)
+RADICALE_PASSWORD=$(python3 "$CONFIG_READER" RADICALE_PASSWORD)
 if [ -z "$RADICALE_URL" ] || [ -z "$RADICALE_USER" ] || [ -z "$RADICALE_PASSWORD" ]; then
     echo "❌ Calendar credentials not configured in infrastructure config"
     exit 1

--- a/wrappers/today
+++ b/wrappers/today
@@ -1,11 +1,9 @@
 #!/bin/bash
 # Show today's calendar events
-CONFIG_FILE=~/claude-autonomy-platform/config/claude_infrastructure_config.txt
-if [ ! -f "$CONFIG_FILE" ]; then
-    echo "❌ Could not find infrastructure config file"
-    exit 1
-fi
-source "$CONFIG_FILE"
+CONFIG_READER=~/claude-autonomy-platform/utils/infrastructure_config_reader.py
+RADICALE_URL=$(python3 "$CONFIG_READER" RADICALE_URL)
+RADICALE_USER=$(python3 "$CONFIG_READER" RADICALE_USER)
+RADICALE_PASSWORD=$(python3 "$CONFIG_READER" RADICALE_PASSWORD)
 if [ -z "$RADICALE_URL" ] || [ -z "$RADICALE_USER" ] || [ -z "$RADICALE_PASSWORD" ]; then
     echo "❌ Calendar credentials not configured in infrastructure config"
     exit 1

--- a/wrappers/week
+++ b/wrappers/week
@@ -1,11 +1,9 @@
 #!/bin/bash
 # Show this week's calendar events
-CONFIG_FILE=~/claude-autonomy-platform/config/claude_infrastructure_config.txt
-if [ ! -f "$CONFIG_FILE" ]; then
-    echo "❌ Could not find infrastructure config file"
-    exit 1
-fi
-source "$CONFIG_FILE"
+CONFIG_READER=~/claude-autonomy-platform/utils/infrastructure_config_reader.py
+RADICALE_URL=$(python3 "$CONFIG_READER" RADICALE_URL)
+RADICALE_USER=$(python3 "$CONFIG_READER" RADICALE_USER)
+RADICALE_PASSWORD=$(python3 "$CONFIG_READER" RADICALE_PASSWORD)
 if [ -z "$RADICALE_URL" ] || [ -z "$RADICALE_USER" ] || [ -z "$RADICALE_PASSWORD" ]; then
     echo "❌ Calendar credentials not configured in infrastructure config"
     exit 1


### PR DESCRIPTION
## Problem
Calendar wrappers (`week`, `today`, `schedule`) were using bash `source` to read the config file, which broke when:
- Config file contains `[CREDENTIALS]` section header (not valid bash syntax)
- `CLAUDE_DISPLAY_NAME` contains parentheses like `🍊 (spark|rest)` (breaks bash parsing)

This caused all calendar commands to fail with config parsing errors.

## Solution
- **Updated `infrastructure_config_reader.py`**: Added CLI argument support to get specific config values
- **Fixed calendar wrappers**: Replaced bash `source` with Python config reader calls
- **Preserves flexibility**: Config file can now use INI-style sections and special characters without breaking wrappers

## Testing
- ✅ Verified `week` and `today` commands work
- ✅ Successfully queried calendars (found Delta's gallery opening events!)
- ✅ Pre-commit hooks passed

## Context
Discovered during autonomous session while investigating Wednesday gallery opening. Fixed as natural Orange infrastructure debugging flow! 🔧✨