### PR TITLE
Migrate three services to clap_logger

### DIFF
--- a/core/session_swap_monitor.py
+++ b/core/session_swap_monitor.py
@@ -8,45 +8,38 @@ import time
 import os
 import subprocess
 from pathlib import Path
-from datetime import datetime
 
 # Import path utilities
 import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'utils'))
 from claude_paths import get_clap_dir
 from infrastructure_config_reader import get_config_value
+from clap_logger import get_logger
 
 # Get dynamic paths
 clap_dir = get_clap_dir()
 
 TRIGGER_FILE = clap_dir / "new_session.txt"
 SCRIPT_PATH = clap_dir / "utils" / "session_swap.sh"
-LOG_PATH = clap_dir / "logs" / "session_swap_monitor.log"
 TMUX_SESSION = "autonomous-claude"
 
-def log(message):
-    """Log with timestamp"""
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    log_entry = f"{timestamp} - {message}"
-    print(log_entry)
-    with open(LOG_PATH, "a") as f:
-        f.write(log_entry + "\n")
+logger = get_logger("session-swap-monitor")
 
 def run_session_swap(keyword="NONE"):
     """Run the session swap script with the given keyword"""
-    log(f"Running session swap with keyword: {keyword}")
+    logger.info("Running session swap with keyword: %s", keyword)
     try:
         result = subprocess.run([str(SCRIPT_PATH), keyword],
                               capture_output=True, text=True)
-        log(f"Session swap completed: {result.returncode}")
+        logger.info("Session swap completed: %s", result.returncode)
         if result.stdout:
-            log(f"Output: {result.stdout}")
+            logger.info("Output: %s", result.stdout)
         if result.stderr:
-            log(f"Error: {result.stderr}")
+            logger.error("Error: %s", result.stderr)
 
         # Note: Session tracking now happens in session_swap.sh after Claude creates the new session
     except Exception as e:
-        log(f"Error running session swap: {e}")
+        logger.error("Error running session swap: %s", e)
 
 def ping_healthcheck():
     """Ping healthchecks.io to signal service is alive"""
@@ -64,19 +57,19 @@ def ping_healthcheck():
         if result.returncode == 0:
             return True
         else:
-            log(f"Healthcheck ping failed: {result.stderr}")
+            logger.warning("Healthcheck ping failed: %s", result.stderr)
             return False
     except Exception as e:
-        log(f"Healthcheck ping error: {e}")
+        logger.warning("Healthcheck ping error: %s", e)
         return False
 
 def main():
-    log("Session swap monitor service started")
-    
+    logger.info("Session swap monitor service started")
+
     # Ensure trigger file exists with default value
     if not TRIGGER_FILE.exists():
         TRIGGER_FILE.write_text("FALSE")
-        log(f"Created trigger file: {TRIGGER_FILE}")
+        logger.info("Created trigger file: %s", TRIGGER_FILE)
 
     # Ping counter for healthchecks (ping every 30 seconds)
     ping_counter = 0
@@ -100,7 +93,7 @@ def main():
                     
                     # Reset trigger file only after successful completion
                     TRIGGER_FILE.write_text("FALSE")
-                    log("Reset trigger file to FALSE after swap completion")
+                    logger.info("Reset trigger file to FALSE after swap completion")
 
             # Ping healthcheck every 30 seconds (15 * 2 seconds)
             ping_counter += 1
@@ -112,10 +105,10 @@ def main():
             time.sleep(2)
             
         except KeyboardInterrupt:
-            log("Service stopped by user")
+            logger.info("Service stopped by user")
             break
         except Exception as e:
-            log(f"Error in main loop: {e}")
+            logger.error("Error in main loop: %s", e)
             time.sleep(5)  # Sleep longer on error
 
 if __name__ == "__main__":

--- a/discord/claude_status_bot.py
+++ b/discord/claude_status_bot.py
@@ -11,40 +11,42 @@ from discord.ext import tasks
 import json
 import asyncio
 from pathlib import Path
-from datetime import datetime
 import sys
 
 # Add utils to path
 sys.path.append(str(Path(__file__).parent.parent / "utils"))
 from infrastructure_config_reader import get_config_value
+from clap_logger import get_logger
+
+logger = get_logger("discord-status-bot")
 
 class ClaudeStatusBot(discord.Client):
     def __init__(self):
-        print("  📍 Initializing bot class...")
+        logger.info("Initializing bot class")
         intents = discord.Intents.default()
         intents.message_content = True
         intents.guilds = True
         intents.presences = True
         super().__init__(intents=intents)
-        print("  📍 Bot class initialized")
+        logger.info("Bot class initialized")
         
         self.status_file = Path(__file__).parent.parent / "data" / "bot_status.json"
         self.last_status_check = None
         self.claude_name = get_config_value('CLAUDE_NAME', 'Claude')
         
     async def on_ready(self):
-        print(f'✅ {self.claude_name} Status Bot logged in as {self.user}')
-        print(f'📊 Connected to {len(self.guilds)} guild(s)')
+        logger.info("%s Status Bot logged in as %s", self.claude_name, self.user)
+        logger.info("Connected to %d guild(s)", len(self.guilds))
         # Set initial status from file if it exists
         await self.update_status_from_file()
         # Start monitoring for changes
         self.status_monitor.start()
-        print('🔄 Status monitor started!')
+        logger.info("Status monitor started")
         
     async def update_status_from_file(self):
         """Update status from the status file"""
         if not self.status_file.exists():
-            print("⚠️ No status file found, using default status")
+            logger.info("No status file found, using default status")
             await self.change_presence(
                 status=discord.Status.online,
                 activity=discord.Activity(
@@ -96,10 +98,10 @@ class ClaudeStatusBot(discord.Client):
                 activity=activity
             )
             
-            print(f"✅ Updated status: {status} - {activity.name if activity else 'No activity'}")
-            
+            logger.info("Updated status: %s - %s", status, activity.name if activity else "No activity")
+
         except Exception as e:
-            print(f"❌ Error updating status: {e}")
+            logger.error("Error updating status: %s", e)
     
     @tasks.loop(seconds=5)
     async def status_monitor(self):
@@ -119,39 +121,34 @@ class ClaudeStatusBot(discord.Client):
             await self.update_status_from_file()
             
         except Exception as e:
-            print(f"❌ Error in status monitor: {e}")
+            logger.error("Error in status monitor: %s", e)
 
 
 async def run_bot():
     """Run the bot asynchronously"""
     token = get_config_value('DISCORD_BOT_TOKEN')
     if not token:
-        print("❌ No Discord bot token found in config")
+        logger.error("No Discord bot token found in config")
         sys.exit(1)
-    
-    print(f"🔧 Starting {get_config_value('CLAUDE_NAME', 'Claude')} Status Bot...")
-    print(f"📁 Status file: {Path(__file__).parent.parent / 'data' / 'bot_status.json'}")
-    sys.stdout.flush()
-    
+
+    logger.info("Starting %s Status Bot...", get_config_value('CLAUDE_NAME', 'Claude'))
+    logger.info("Status file: %s", Path(__file__).parent.parent / 'data' / 'bot_status.json')
+
     bot = ClaudeStatusBot()
-    
+
     try:
-        print("🔌 Attempting to connect to Discord...")
-        sys.stdout.flush()
+        logger.info("Attempting to connect to Discord...")
         await bot.start(token)
     except discord.LoginFailure as e:
-        print(f"❌ Discord login failed: {e}")
+        logger.error("Discord login failed: %s", e)
         sys.exit(1)
     except Exception as e:
-        print(f"❌ Bot error: {e}")
-        import traceback
-        traceback.print_exc()
+        logger.error("Bot error: %s", e, exc_info=True)
         sys.exit(1)
 
 if __name__ == "__main__":
-    print(f"🚀 Starting bot at {datetime.now()}")
-    sys.stdout.flush()
+    logger.info("Starting bot")
     try:
         asyncio.run(run_bot())
     except KeyboardInterrupt:
-        print("\n👋 Status bot shutting down...")
+        logger.info("Status bot shutting down")

--- a/discord/discord_transcript_fetcher.py
+++ b/discord/discord_transcript_fetcher.py
@@ -35,6 +35,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from discord.channel_state import ChannelState
 from discord.discord_tools import DiscordTools
 from utils.infrastructure_config_reader import get_config_value
+from utils.clap_logger import get_logger
+
+logger = get_logger("discord-transcript-fetcher")
 
 # Configuration
 CLAP_ROOT = Path(__file__).parent.parent
@@ -70,9 +73,9 @@ class TranscriptFetcher:
         # If no channels exist yet, start with general
         if not self.channels_to_track:
             self.channels_to_track = ['general']
-            print("⚠️  No channels in state yet, starting with ['general']")
+            logger.warning("No channels in state yet, starting with ['general']")
         else:
-            print(f"📡 Tracking {len(self.channels_to_track)} channels from state")
+            logger.info("Tracking %d channels from state", len(self.channels_to_track))
 
     def initialize_channels(self):
         """Initialize tracked channels if not already in state"""
@@ -82,7 +85,7 @@ class TranscriptFetcher:
                 channel_id = self._get_channel_id(channel_name)
                 if channel_id:
                     self.channel_state.add_channel(channel_id, channel_name)
-                    print(f"Added channel to tracking: {channel_name} ({channel_id})")
+                    logger.info("Added channel to tracking: %s (%s)", channel_name, channel_id)
 
     def _get_channel_id(self, channel_name):
         """Get Discord channel ID from name"""
@@ -91,7 +94,7 @@ class TranscriptFetcher:
             channel_id = self.discord.resolve_channel(channel_name)
             return channel_id
         except Exception as e:
-            print(f"Error resolving channel {channel_name}: {e}")
+            logger.error("Error resolving channel %s: %s", channel_name, e)
             return None
 
     def fetch_new_messages(self, channel_name):
@@ -110,7 +113,7 @@ class TranscriptFetcher:
             result = self.discord.read_messages(channel_name, limit=limit)
 
             if not result.get('success'):
-                print(f"Failed to read channel {channel_name}: {result.get('error')}")
+                logger.warning("Failed to read channel %s: %s", channel_name, result.get('error'))
                 return []
 
             messages = result.get('messages', [])
@@ -126,7 +129,7 @@ class TranscriptFetcher:
             return messages
 
         except Exception as e:
-            print(f"Error fetching messages for {channel_name}: {e}")
+            logger.error("Error fetching messages for %s: %s", channel_name, e)
             return []
 
     def get_attachment_info(self, message, channel_name):
@@ -190,7 +193,7 @@ class TranscriptFetcher:
             f.flush()
             os.fsync(f.fileno())
 
-        print(f"Appended {len(messages)} messages to {channel_name} transcript")
+        logger.info("Appended %d messages to %s transcript", len(messages), channel_name)
 
     def update_channel_state(self, channel_name, messages):
         """Update channel state after processing messages"""
@@ -227,7 +230,7 @@ class TranscriptFetcher:
         for message in messages:
             content = message.get('content', '')
             if re.search(pattern, content, re.IGNORECASE):
-                print(f"[{datetime.now().strftime('%H:%M:%S')}] 🐔 Mama-hen alert detected for {my_name}!")
+                logger.info("Mama-hen alert detected for %s", my_name)
 
                 # Trigger send_to_claude to wake up the Claude session
                 try:
@@ -246,14 +249,14 @@ class TranscriptFetcher:
                     )
 
                     if result.returncode == 0:
-                        print(f"[{datetime.now().strftime('%H:%M:%S')}] 🐔 Sent Mama-hen nudge to Claude session")
+                        logger.info("Sent Mama-hen nudge to Claude session")
                     else:
-                        print(f"[{datetime.now().strftime('%H:%M:%S')}] WARNING: Failed to send Mama-hen nudge: {result.stderr}")
+                        logger.warning("Failed to send Mama-hen nudge: %s", result.stderr)
 
                 except subprocess.TimeoutExpired:
-                    print(f"[{datetime.now().strftime('%H:%M:%S')}] WARNING: Mama-hen nudge timed out (Claude may be busy)")
+                    logger.warning("Mama-hen nudge timed out (Claude may be busy)")
                 except Exception as e:
-                    print(f"[{datetime.now().strftime('%H:%M:%S')}] ERROR: Mama-hen nudge failed: {e}")
+                    logger.error("Mama-hen nudge failed: %s", e)
 
                 # Only process first matching alert
                 return
@@ -275,19 +278,16 @@ class TranscriptFetcher:
                 if channel_name == 'system-messages':
                     self.check_mama_hen_alert(messages)
 
-                print(f"[{datetime.now().strftime('%H:%M:%S')}] Processed {len(messages)} new messages in #{channel_name}")
+                logger.info("Processed %d new messages in #%s", len(messages), channel_name)
 
         except Exception as e:
-            print(f"Error processing channel {channel_name}: {e}")
+            logger.error("Error processing channel %s: %s", channel_name, e)
 
     def run(self):
         """Main loop: monitor channels and build transcripts"""
-        print("Starting Discord Transcript Fetcher")
-        print(f"Tracking channels: {', '.join(self.channels_to_track)}")
-        print(f"Check interval: {CHECK_INTERVAL}s")
-        print(f"Transcripts: {TRANSCRIPT_DIR}")
-        print(f"Attachments: {ATTACHMENTS_DIR}")
-        print("---")
+        logger.info("Starting Discord Transcript Fetcher")
+        logger.info("Tracking channels: %s", ", ".join(self.channels_to_track))
+        logger.info("Check interval: %ds | Transcripts: %s", CHECK_INTERVAL, TRANSCRIPT_DIR)
 
         # Initialize channels
         self.initialize_channels()
@@ -302,10 +302,10 @@ class TranscriptFetcher:
                 time.sleep(CHECK_INTERVAL)
 
             except KeyboardInterrupt:
-                print("\nStopping transcript fetcher...")
+                logger.info("Stopping transcript fetcher")
                 break
             except Exception as e:
-                print(f"Error in main loop: {e}")
+                logger.error("Error in main loop: %s", e)
                 time.sleep(CHECK_INTERVAL)
 
 


### PR DESCRIPTION
## Summary
- Migrate `session_swap_monitor.py`, `claude_status_bot.py`, and `discord_transcript_fetcher.py` from raw `print()`/custom `log()` to the shared `clap_logger` module (#268)
- Consistent `[timestamp] [level] [component]` format across all three services
- Gains rotating file handlers (10MB, 5 backups) and automatic flush

## Details
First batch of the logging migration outlined in the logging proposal. These three services were chosen because they're simple (121-319 lines each) and run as systemd services where consistent logging matters most.

No behavioral changes — just log output formatting and file rotation.

## Test plan
- [ ] Verify `session-swap-monitor.service` starts and logs correctly
- [ ] Verify `discord-status-bot.service` starts and logs correctly
- [ ] Verify `discord-transcript-fetcher.service` starts and logs correctly
- [ ] Check log files appear in `logs/` with correct format

🤖 Generated with [Claude Code](https://claude.com/claude-code)