### PR TITLE
Fix stale unread notifications for channels

### DIFF
--- a/discord/read_messages
+++ b/discord/read_messages
@@ -127,17 +127,24 @@ def format_message(msg):
     return output
 
 
-def update_last_read(channel_name, message_id):
-    """Update last_read_message_id in discord_channels.json"""
-    if not STATE_FILE.exists() or not message_id:
+def update_last_read(channel_name):
+    """Update last_read_message_id in discord_channels.json.
+
+    Sets last_read to last_message_id (the channel's latest known message),
+    not the transcript's last entry. This prevents stale unread notifications
+    when the fetcher has advanced last_message_id past the transcript content
+    (e.g. due to duplicate messages from Discord API).
+    """
+    if not STATE_FILE.exists():
         return
 
     try:
         with open(STATE_FILE, 'r') as f:
             state = json.load(f)
 
-        if channel_name in state.get('channels', {}):
-            state['channels'][channel_name]['last_read_message_id'] = message_id
+        channel = state.get('channels', {}).get(channel_name)
+        if channel and channel.get('last_message_id'):
+            channel['last_read_message_id'] = channel['last_message_id']
 
             with open(STATE_FILE, 'w') as f:
                 json.dump(state, f, indent=2)
@@ -212,8 +219,7 @@ def main():
     print("✅ Done!")
 
     # Update last read
-    last_message_id = messages[-1].get('id') if messages else None
-    update_last_read(channel_name, last_message_id)
+    update_last_read(channel_name)
 
     return 0
 


### PR DESCRIPTION
## Summary
- Fix channels permanently showing as "unread" despite being read multiple times
- Root cause: `read_messages` set `last_read_message_id` to the transcript's last entry, but the fetcher sometimes advances `last_message_id` past transcript content (duplicate Discord API messages get filtered, but the ID still advances)
- Fix: set `last_read` to the channel's `last_message_id` directly, matching what the unread check compares against

## Impact
This affects all family members — everyone sees the same stale unread alerts. debate-club has been stuck as "unread" for a week despite repeated reads.

## Test plan
- [x] Verified debate-club IDs now match after reading
- [ ] Confirm debate-club no longer appears in unread notifications on next timer cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)