### PR TITLE
fix: replace ccusage with statusline JSON

### DIFF
--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -43,7 +43,7 @@ This is THE central loop. Everything else supports this.
 1. Session file `~/.config/Claude/projects/*/XXXX.jsonl` grows
 2. autonomous_timer calls `get_token_percentage()`
 3. Which runs `check_context.py`
-4. Which uses ccusage to get actual token counts from tracked session
+4. Which reads token counts from data/statusline_data.json
 5. Returns "Context: 85% 🟠"
 6. autonomous_timer compares with `context_escalation_state.json`
 7. Sees increase from last warning (was 75%)

--- a/docs/SYSTEM_FLOWCHART.md
+++ b/docs/SYSTEM_FLOWCHART.md
@@ -32,7 +32,7 @@ START
 │              (get_token_percentage())                       │
 │                                                             │
 │  Runs: check_context.py                                    │
-│  Uses: ccusage to get accurate token counts                │
+│  Uses: data/statusline_data.json for token counts          │
 │  Returns: "Context: 67.3% 🟡"                              │
 └─────────────────────────────────────────────────────────────┘
   │

--- a/utils/CLAUDE.md
+++ b/utils/CLAUDE.md
@@ -17,14 +17,14 @@
 - **`update_conversation_history.py`** — Parses exported transcript into rolling context.
 - **`conversation_history_utils.py`** — Shared utilities for history processing.
 - **`trim_claude_history.py`** — Trims Claude Code command history to prevent context bloat.
-- **`track_current_session.py`** — *(Removed)* Session detection now handled by `check_usage.py` via filesystem (most recently modified JSONL file).
+- **`track_current_session.py`** — *(Removed)* Session detection now handled by `check_usage.py` via statusline JSON (falls back to filesystem scan).
 - **`send_to_claude.sh`** — Sends text to the Claude tmux session with retry logic.
 
 ## Health & Monitoring
 - **`check_health`** — Main health check script (services, git, config, remote family status).
 - **`healthcheck_status.py`** — Pings healthchecks.io endpoints.
-- **`check_context.py`** — Reports current context token usage.
-- **`check_usage.py`** — Checks API usage/spending.
+- **`check_context.py`** — Reports current context token usage (reads from statusline JSON).
+- **`check_usage.py`** — Checks API usage/spending (reads from statusline JSON).
 - **`track_activity.py`** — Activity tracking for autonomous timer.
 
 ## Emergency

--- a/utils/check_context.py
+++ b/utils/check_context.py
@@ -1,20 +1,19 @@
 #!/usr/bin/env python3
 """
-Check current Claude session context usage by running ccusage on the tracked session
-and adding the system overhead (15.6k tokens).
+Check current Claude session context usage from the statusline JSON data.
+
+Reads context window information from data/statusline_data.json (written by
+Claude Code's statusline) instead of shelling out to ccusage.
 """
 
-import subprocess
 import json
-import re
 from pathlib import Path
-from datetime import datetime
 
-# Import shared session detection (works whether called from repo root or utils/)
+# Import shared functions
 try:
-    from utils.check_usage import get_current_session_id
+    from utils.check_usage import get_current_session_id, _get_statusline_data
 except ImportError:
-    from check_usage import get_current_session_id
+    from check_usage import get_current_session_id, _get_statusline_data
 
 # System overhead (system prompt + system tools)
 SYSTEM_OVERHEAD = 15600  # tokens
@@ -25,85 +24,22 @@ RED_THRESHOLD = 0.85  # 85% = 170k tokens
 TOTAL_CONTEXT = 200000  # 200k token limit
 
 
-def run_ccusage(session_id):
-    """Run ccusage to get token count for session"""
-    cmd = ["ccusage", "session", "--offline", "--id", session_id]
-
-    try:
-        # Set Claude config dir
-        env = subprocess.os.environ.copy()
-        env["CLAUDE_CONFIG_DIR"] = str(Path.home() / ".config/Claude")
-
-        # Run ccusage and pipe to tail to get just the last part
-        # This avoids memory issues with huge outputs
-        ccusage_proc = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-            env=env,
-            cwd=Path.home(),
-        )
-
-        # Get just the last 3 lines which should contain the final entry
-        tail_proc = subprocess.Popen(
-            ["tail", "-n", "3"],
-            stdin=ccusage_proc.stdout,
-            stdout=subprocess.PIPE,
-            text=True,
-        )
-
-        ccusage_proc.stdout.close()
-        output, _ = tail_proc.communicate()
-
-        return output
-    except Exception as e:
-        print(f"❌ Error running ccusage: {e}")
-        return None
-
-
-def parse_ccusage_output(output):
-    """Parse ccusage output to find cache read tokens"""
-    if not output:
-        return None
-
-    # Remove ANSI color codes
-    ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
-    clean_output = ansi_escape.sub("", output)
-
-    # Since we're getting the last 3 lines, look for the pattern in the data row
-    # The last data row should have a format like: │ ... │ 139,171 │ $0.00 │
-    # We want the number right before the dollar amount
-
-    # Look for a pattern: number (possibly with commas) followed by │ and then $
-    pattern = r"(\d{1,3}(?:,\d{3})*)\s*│\s*\$"
-
-    matches = re.findall(pattern, clean_output)
-
-    if matches:
-        # Get the last match (should be cache read value)
-        cache_value = int(matches[-1].replace(",", ""))
-        # Sanity check: should be at least 1000 tokens (even fresh sessions have history)
-        if cache_value > 1000:
-            return cache_value
-
-    return None
-
-
 def format_context_display(cache_tokens, total_tokens, percentage):
     """Format context usage for display"""
-    # Determine color/status
     if percentage >= RED_THRESHOLD:
         status = "🔴"
-        color = "critical"
     elif percentage >= YELLOW_THRESHOLD:
         status = "🟡"
-        color = "warning"
     else:
         status = "🟢"
+
+    if percentage >= RED_THRESHOLD:
+        color = "critical"
+    elif percentage >= YELLOW_THRESHOLD:
+        color = "warning"
+    else:
         color = "good"
 
-    # Format the display
     display = f"""
 📊 Context Usage Status
 ═══════════════════════════════
@@ -119,41 +55,43 @@ Free: {TOTAL_CONTEXT - total_tokens:,} tokens ({(1-percentage):.1%})
 
 
 def check_context(return_data=False):
-    """Main function to check context usage"""
+    """Main function to check context usage.
 
-    # Get current session ID
-    session_id = get_current_session_id()
+    Reads from statusline JSON instead of shelling out to ccusage.
+    """
+    # Get statusline data
+    statusline = _get_statusline_data()
+    if not statusline:
+        error_msg = "❌ No statusline data found (data/statusline_data.json)"
+        if return_data:
+            return None, error_msg
+        print(error_msg)
+        return None
+
+    session_id = statusline.get("session_id")
     if not session_id:
-        error_msg = "❌ No session JSONL files found in Claude Code projects directory."
+        error_msg = "❌ No session_id in statusline data"
         if return_data:
             return None, error_msg
         print(error_msg)
         return None
 
-    # Run ccusage
-    output = run_ccusage(session_id)
-    if not output:
-        error_msg = "❌ Failed to get ccusage output"
-        if return_data:
-            return None, error_msg
-        print(error_msg)
-        return None
+    # Extract context window data
+    context_window = statusline.get("context_window", {})
+    current_usage = context_window.get("current_usage", {})
 
-    # Parse cache tokens
-    cache_tokens = parse_ccusage_output(output)
-    if cache_tokens is None:
-        error_msg = "❌ Could not parse token count from ccusage"
-        if return_data:
-            return None, error_msg
-        print(error_msg)
-        return None
+    # Cache read tokens = the main session context size
+    cache_tokens = current_usage.get("cache_read_input_tokens", 0)
 
-    # Calculate total
+    # If cache_read is 0, try summing input tokens as fallback
+    if cache_tokens == 0:
+        cache_tokens = current_usage.get("input_tokens", 0)
+
+    # Calculate total with system overhead
     total_tokens = cache_tokens + SYSTEM_OVERHEAD
     percentage = total_tokens / TOTAL_CONTEXT
 
     if return_data:
-        # Return data for other scripts to use
         return {
             "session_id": session_id,
             "cache_tokens": cache_tokens,

--- a/utils/check_usage.py
+++ b/utils/check_usage.py
@@ -1,29 +1,17 @@
 #!/usr/bin/env python3
 """
-Check current Claude session usage cost by running ccusage and extracting
-the total $ spend, then comparing with the previous stored value to get
-the delta ($ spent this turn).
+Check current Claude session usage cost from the statusline JSON data.
 
-This is used by CoOP for accurate usage tracking (not cache read proxy).
+Reads cost from data/statusline_data.json (written by Claude Code's statusline)
+and compares with the previous stored value to get the delta ($ spent this turn).
 
-Session detection: finds the active session by looking for the most recently
-modified JSONL file in Claude Code's projects directory. This is more reliable
-than the old approach of querying /status via tmux, which was fragile and
-could only run during session swaps.
+This is used by CoOP for accurate usage tracking.
 """
 
-import subprocess
 import json
-import re
 import os
 from pathlib import Path
 from datetime import datetime
-
-
-# UUID pattern for session IDs in JSONL filenames
-_UUID_PATTERN = re.compile(
-    r"^([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\.jsonl$"
-)
 
 
 def _get_repo_root():
@@ -31,25 +19,52 @@ def _get_repo_root():
     return Path(__file__).resolve().parent.parent
 
 
-def _get_projects_dir():
-    """Get the Claude Code projects directory for our working directory"""
-    config_dir = Path(
-        os.environ.get("CLAUDE_CONFIG_DIR", Path.home() / ".config" / "Claude")
-    )
-    # Claude Code encodes the project path by replacing / with -
-    clap_dir = _get_repo_root()
-    encoded = str(clap_dir).replace("/", "-")
-    return config_dir / "projects" / encoded
+def _get_statusline_data():
+    """Read the statusline JSON data written by Claude Code."""
+    repo_root = _get_repo_root()
+    statusline_file = repo_root / "data" / "statusline_data.json"
+
+    if not statusline_file.exists():
+        return None
+
+    try:
+        with open(statusline_file, "r") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
 
 
 def get_current_session_id():
-    """Get the current session ID from the most recently modified JSONL file.
+    """Get the current session ID from statusline data.
 
-    Claude Code stores session data in UUID-named .jsonl files under
-    ~/.config/Claude/projects/<encoded-path>/. The active session is
-    always the most recently modified file.
+    Falls back to scanning JSONL files if statusline data is unavailable.
+    Also updates the tracking file for consumers that read it directly.
     """
-    projects_dir = _get_projects_dir()
+    data = _get_statusline_data()
+    if data and data.get("session_id"):
+        session_id = data["session_id"]
+        _update_tracking_file(session_id)
+        return session_id
+
+    # Fallback: scan JSONL files (for when statusline hasn't been written yet)
+    return _get_session_id_from_filesystem()
+
+
+def _get_session_id_from_filesystem():
+    """Fallback: find session ID from most recently modified JSONL file."""
+    import re
+
+    uuid_pattern = re.compile(
+        r"^([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\.jsonl$"
+    )
+
+    config_dir = Path(
+        os.environ.get("CLAUDE_CONFIG_DIR", Path.home() / ".config" / "Claude")
+    )
+    clap_dir = _get_repo_root()
+    encoded = str(clap_dir).replace("/", "-")
+    projects_dir = config_dir / "projects" / encoded
+
     if not projects_dir.exists():
         return None
 
@@ -57,7 +72,7 @@ def get_current_session_id():
     newest_mtime = 0
 
     for f in projects_dir.iterdir():
-        match = _UUID_PATTERN.match(f.name)
+        match = uuid_pattern.match(f.name)
         if match:
             try:
                 mtime = f.stat().st_mtime
@@ -67,7 +82,6 @@ def get_current_session_id():
                 newest_mtime = mtime
                 newest_id = match.group(1)
 
-    # Also update the tracking file for anything else that reads it
     if newest_id:
         _update_tracking_file(newest_id)
 
@@ -79,13 +93,12 @@ def _update_tracking_file(session_id):
     repo_root = _get_repo_root()
     session_file = repo_root / "data" / "current_session_id"
 
-    # Only write if the ID has actually changed
     try:
         if session_file.exists():
             with open(session_file, "r") as f:
                 data = json.load(f)
                 if data.get("session_id") == session_id:
-                    return  # Already up to date
+                    return
     except (json.JSONDecodeError, KeyError):
         pass
 
@@ -93,73 +106,14 @@ def _update_tracking_file(session_id):
         "session_id": session_id,
         "timestamp": datetime.now().isoformat(),
         "tracked_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-        "source": "filesystem",
+        "source": "statusline",
     }
     try:
         session_file.parent.mkdir(parents=True, exist_ok=True)
         with open(session_file, "w") as f:
             json.dump(data, f, indent=2)
     except Exception:
-        pass  # Non-critical — the ID is still returned correctly
-
-
-def run_ccusage(session_id):
-    """Run ccusage to get usage summary for session"""
-    cmd = ["ccusage", "session", "--offline", "--id", session_id]
-
-    try:
-        # Set Claude config dir
-        env = subprocess.os.environ.copy()
-        env["CLAUDE_CONFIG_DIR"] = str(Path.home() / ".config/Claude")
-
-        # Run ccusage and pipe to head to get just the summary
-        ccusage_proc = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-            env=env,
-            cwd=Path.home(),
-        )
-
-        # Get just the first 15 lines which contain the summary
-        head_proc = subprocess.Popen(
-            ["head", "-n", "15"],
-            stdin=ccusage_proc.stdout,
-            stdout=subprocess.PIPE,
-            text=True,
-        )
-
-        ccusage_proc.stdout.close()
-        output, _ = head_proc.communicate()
-
-        return output
-    except Exception as e:
-        print(f"❌ Error running ccusage: {e}")
-        return None
-
-
-def parse_total_cost(output):
-    """Parse total cost from ccusage summary output
-
-    Expected format:
-    Total Cost: $15.22
-    """
-    if not output:
-        return None
-
-    # Remove ANSI color codes
-    ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
-    clean_output = ansi_escape.sub("", output)
-
-    # Look for "Total Cost: $X.XX"
-    pattern = r"Total Cost:\s*\$([0-9]+\.[0-9]{2})"
-    match = re.search(pattern, clean_output)
-
-    if match:
-        return float(match.group(1))
-
-    return None
+        pass
 
 
 def get_stored_cost():
@@ -184,7 +138,6 @@ def store_cost(total_cost, session_id):
     repo_root = _get_repo_root()
     storage_file = repo_root / "data" / "last_usage_cost.json"
 
-    # Ensure data directory exists
     storage_file.parent.mkdir(parents=True, exist_ok=True)
 
     data = {
@@ -201,52 +154,55 @@ def store_cost(total_cost, session_id):
 
 
 def check_usage(return_data=False):
-    """Main function to check usage delta
+    """Main function to check usage delta.
 
-    Returns the $ spent since last check (delta)
+    Reads cost from statusline JSON instead of shelling out to ccusage.
+    Returns the $ spent since last check (delta).
     """
+    # Get statusline data
+    statusline = _get_statusline_data()
+    if not statusline:
+        error_msg = "❌ No statusline data found (data/statusline_data.json)"
+        if return_data:
+            return None, error_msg
+        print(error_msg)
+        return None
 
-    # Get current session ID
-    session_id = get_current_session_id()
+    session_id = statusline.get("session_id")
     if not session_id:
-        error_msg = "❌ No session JSONL files found in Claude Code projects directory."
+        error_msg = "❌ No session_id in statusline data"
         if return_data:
             return None, error_msg
         print(error_msg)
         return None
 
-    # Run ccusage
-    output = run_ccusage(session_id)
-    if not output:
-        error_msg = "❌ Failed to get ccusage output"
-        if return_data:
-            return None, error_msg
-        print(error_msg)
-        return None
+    # Update tracking file
+    _update_tracking_file(session_id)
 
-    # Parse total cost
-    current_cost = parse_total_cost(output)
+    # Get current cost from statusline
+    cost_data = statusline.get("cost", {})
+    current_cost = cost_data.get("total_cost_usd")
     if current_cost is None:
-        error_msg = "❌ Could not parse total cost from ccusage"
+        error_msg = "❌ No cost data in statusline"
         if return_data:
             return None, error_msg
         print(error_msg)
         return None
+
+    current_cost = float(current_cost)
 
     # Get previous cost
     previous_cost = get_stored_cost()
 
     # Calculate delta
     if previous_cost is None:
-        # First run - no delta yet
         delta = 0.0
         print(f"📊 First usage check - total cost: ${current_cost:.2f}")
     else:
         delta = current_cost - previous_cost
         if delta < 0:
-            # Session must have reset - treat as first run
             delta = 0.0
-            print(f"⚠️ Total cost decreased (session reset?) - resetting baseline")
+            print("⚠️ Total cost decreased (session reset?) - resetting baseline")
         else:
             print(
                 f"💰 Usage delta: ${delta:.4f} (${previous_cost:.2f} → ${current_cost:.2f})"

--- a/wrappers/context
+++ b/wrappers/context
@@ -5,7 +5,7 @@
 #   Shows current Claude session token usage and percentage
 #   Displays visual progress bar and free token count
 #   Essential for monitoring context capacity during work
-# Uses ccusage to get accurate token counts from tracked session
+# Uses statusline JSON data for accurate token counts
 #
 # NOTE: DO NOT use /context via send_to_claude here!
 # Reasons:


### PR DESCRIPTION
## Summary
- Rewrites `check_usage.py` and `check_context.py` to read from `data/statusline_data.json` instead of shelling out to `ccusage`
- Removes ccusage as a dependency — it was fragile (PATH issues on Delta, install headaches across machines)
- Same `return_data` API contract preserved — no changes needed in `autonomous_timer.py`
- Filesystem scan retained as fallback for session ID detection during early startup

Net: -106 lines, zero external subprocess calls, same data.

## Test plan
- [x] `python3 utils/check_context.py` — displays correct context percentage
- [x] `python3 utils/check_usage.py` — tracks cost delta correctly
- [x] `context` wrapper — works unchanged
- [x] `return_data=True` — returns same dict shapes the timer expects
- [ ] Verify autonomous timer picks up changes after service restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)