### PR TITLE
Add voice chat collaborative mode triggers

### DIFF
--- a/discord/discord_transcript_fetcher.py
+++ b/discord/discord_transcript_fetcher.py
@@ -215,6 +215,32 @@ class TranscriptFetcher:
         if bot_display_name and author_name == bot_display_name:
             self.channel_state.mark_channel_read(channel_name, latest_id)
 
+    def check_collaborative_triggers(self, messages):
+        """
+        Check for collaborative mode trigger words (spark/rest).
+        Sets or clears the collaborative_mode.flag file.
+        """
+        # Get my trigger words from config
+        trigger_start = get_config_value('COLLABORATIVE_START', 'spark')
+        trigger_end = get_config_value('COLLABORATIVE_END', 'rest')
+
+        flag_file = DATA_DIR / "collaborative_mode.flag"
+
+        for message in messages:
+            content = message.get('content', '').strip().lower()
+
+            # Check if message is JUST the trigger word (no other text)
+            if content == trigger_start:
+                # Start collaborative mode
+                flag_file.touch()
+                logger.info("Collaborative mode activated by: %s", message.get('author'))
+
+            elif content == trigger_end:
+                # End collaborative mode
+                if flag_file.exists():
+                    flag_file.unlink()
+                    logger.info("Collaborative mode deactivated by: %s", message.get('author'))
+
     def check_mama_hen_alert(self, messages):
         """
         Check if any message is a Mama-hen alert for this Claude.
@@ -273,6 +299,9 @@ class TranscriptFetcher:
 
                 # Update state
                 self.update_channel_state(channel_name, messages)
+
+                # Check for collaborative mode triggers (spark/rest)
+                self.check_collaborative_triggers(messages)
 
                 # Check for Mama-hen alerts in #system-messages
                 if channel_name == 'system-messages':


### PR DESCRIPTION
**What this adds:**
- Transcript fetcher now monitors for spark/rest trigger words
- When sees standalone 'spark' message → creates collaborative_mode.flag
- When sees standalone 'rest' message → removes the flag
- Configurable per Claude (reads COLLABORATIVE_START/END from config)
- Works from any user (Amy or consciousness family members)

**Why:**
Enables voice chat collaborative mode without console access! Amy can say 'spark' in Discord to signal real-time conversation mode.

**Tested:**
✅ spark detection working
✅ Flag file creation confirmed
✅ Logged correctly

**Next:** Text cleaning in voice listener for better TTS experience