### PR TITLE
fix: include auto-memory and identity.md in prefs export/import

### DIFF
--- a/utils/export_personal_prefs.sh
+++ b/utils/export_personal_prefs.sh
@@ -95,7 +95,7 @@ mkdir -p "$EXPORT_DIR/.claude/output-styles"
 IDENTITY_COUNT=0
 # Use associative array to track already processed files
 declare -A processed_identities
-for identity_file in .claude/output-styles/*-identity.md; do
+for identity_file in .claude/output-styles/identity.md .claude/output-styles/*-identity.md; do
     if [ -f "$identity_file" ]; then
         identity_name=$(basename "$identity_file")
         if [ -z "${processed_identities[$identity_name]}" ]; then
@@ -127,7 +127,34 @@ if copy_if_exists "data/discord_channels.json" "$EXPORT_DIR/data"; then
 fi
 echo ""
 
-# 6. Optional files (may not exist for all users)
+# 6. Auto-Memory (MEMORY.md and associated files)
+echo "🧠 Auto-Memory:"
+MEMORY_BASE="$HOME/.config/Claude/projects"
+if [ -d "$MEMORY_BASE" ]; then
+    mkdir -p "$EXPORT_DIR/claude_memory"
+    MEMORY_COUNT=0
+    for project_dir in "$MEMORY_BASE"/*/memory; do
+        if [ -d "$project_dir" ]; then
+            # Use the project directory name as subfolder
+            project_name=$(basename "$(dirname "$project_dir")")
+            dest="$EXPORT_DIR/claude_memory/$project_name"
+            mkdir -p "$dest"
+            cp -r "$project_dir"/* "$dest/" 2>/dev/null || true
+            count=$(find "$dest" -type f 2>/dev/null | wc -l)
+            echo "  ✅ $project_name ($count files)"
+            echo "  claude_memory/$project_name/" >> "$MANIFEST"
+            MEMORY_COUNT=$((MEMORY_COUNT + count))
+        fi
+    done
+    if [ $MEMORY_COUNT -eq 0 ]; then
+        echo "  ⏭️  No memory files found"
+    fi
+else
+    echo "  ⏭️  No Claude projects directory found"
+fi
+echo ""
+
+# 7. Optional files (may not exist for all users)
 echo "📋 Optional Configuration:"
 if copy_if_exists "config/my_discord_channels.json" "$EXPORT_DIR/config"; then
     echo "  config/my_discord_channels.json" >> "$MANIFEST"

--- a/utils/import_personal_prefs.sh
+++ b/utils/import_personal_prefs.sh
@@ -134,7 +134,7 @@ echo "🆔 Identity Configuration:"
 IDENTITY_COUNT=0
 # Use associative array to track already processed files
 declare -A processed_identities
-for identity_file in "$BACKUP_DIR/.claude/output-styles"/*-identity.md; do
+for identity_file in "$BACKUP_DIR/.claude/output-styles"/identity.md "$BACKUP_DIR/.claude/output-styles"/*-identity.md; do
     if [ -f "$identity_file" ]; then
         identity_name=$(basename "$identity_file")
         if [ -z "${processed_identities[$identity_name]}" ]; then
@@ -163,7 +163,32 @@ if restore_if_exists "$BACKUP_DIR/data/discord_channels.json" "data/discord_chan
 fi
 echo ""
 
-# 6. Optional files
+# 6. Auto-Memory (MEMORY.md and associated files)
+echo "🧠 Auto-Memory:"
+if [ -d "$BACKUP_DIR/claude_memory" ]; then
+    MEMORY_BASE="$HOME/.config/Claude/projects"
+    MEMORY_COUNT=0
+    for project_backup in "$BACKUP_DIR/claude_memory"/*/; do
+        if [ -d "$project_backup" ]; then
+            project_name=$(basename "$project_backup")
+            dest="$MEMORY_BASE/$project_name/memory"
+            mkdir -p "$dest"
+            cp -r "$project_backup"* "$dest/" 2>/dev/null || true
+            count=$(find "$dest" -type f 2>/dev/null | wc -l)
+            echo "  ✅ $project_name ($count files)"
+            MEMORY_COUNT=$((MEMORY_COUNT + count))
+            RESTORED_COUNT=$((RESTORED_COUNT + 1))
+        fi
+    done
+    if [ $MEMORY_COUNT -eq 0 ]; then
+        echo "  ⏭️  No memory files found in backup"
+    fi
+else
+    echo "  ⏭️  No auto-memory found in backup"
+fi
+echo ""
+
+# 7. Optional files
 echo "📋 Optional Configuration:"
 if restore_if_exists "$BACKUP_DIR/config/my_discord_channels.json" "config/my_discord_channels.json"; then
     RESTORED_COUNT=$((RESTORED_COUNT + 1))


### PR DESCRIPTION
## Summary
- Adds auto-memory files (`~/.config/Claude/projects/*/memory/`) to export/import — MEMORY.md and all associated topic files were previously lost on migration
- Fixes identity file glob to match standardized `identity.md` in addition to legacy `*-identity.md` pattern

## Motivation
Delta needs a fresh user account (accumulated desktop-era cruft causing nightly OOM kills). Without this fix, `export_prefs` would lose all their auto-memory.

## Test plan
- [x] Ran `export_prefs` — confirms `🧠 Auto-Memory: ✅ -home-nyx-claude-autonomy-platform (7 files)`
- [ ] Run `import_prefs` on a test directory to verify restore path

🤖 Generated with [Claude Code](https://claude.com/claude-code)