### PR TITLE
feat: auto-backup identity files during session swap

### DIFF
--- a/utils/backup_identity.sh
+++ b/utils/backup_identity.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Backup identity and memory files to personal repo
+# Called during session swap to maintain versioned backups
+# Skips silently if nothing changed or personal repo not configured
+
+set -e
+
+CLAP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$CLAP_DIR/config/claude_env.sh"
+
+PERSONAL_DIR=$(read_config "PERSONAL_DIR" 2>/dev/null || echo "")
+if [[ -z "$PERSONAL_DIR" || ! -d "$PERSONAL_DIR" ]]; then
+    echo "[IDENTITY_BACKUP] No personal repo configured, skipping"
+    exit 0
+fi
+
+# Ensure backup directory exists
+BACKUP_DIR="$PERSONAL_DIR/.identity-backup"
+mkdir -p "$BACKUP_DIR/output-styles"
+mkdir -p "$BACKUP_DIR/auto-memory"
+
+CHANGED=0
+
+# Backup identity/output-style files
+for f in "$CLAP_DIR/.claude/output-styles/"*identity*.md "$CLAP_DIR/.claude/output-styles/identity.md"; do
+    if [[ -f "$f" ]]; then
+        dest="$BACKUP_DIR/output-styles/$(basename "$f")"
+        if ! cmp -s "$f" "$dest" 2>/dev/null; then
+            cp "$f" "$dest"
+            CHANGED=1
+        fi
+    fi
+done
+
+# Backup auto-memory files
+# Find the auto-memory directory for this ClAP project
+MEMORY_DIR="$HOME/.config/Claude/projects/-$(echo "$CLAP_DIR" | sed 's|/|-|g; s|^-||')/memory"
+if [[ -d "$MEMORY_DIR" ]]; then
+    for f in "$MEMORY_DIR"/*.md; do
+        if [[ -f "$f" ]]; then
+            dest="$BACKUP_DIR/auto-memory/$(basename "$f")"
+            if ! cmp -s "$f" "$dest" 2>/dev/null; then
+                cp "$f" "$dest"
+                CHANGED=1
+            fi
+        fi
+    done
+fi
+
+# Commit and push if anything changed
+if [[ $CHANGED -eq 1 ]]; then
+    cd "$PERSONAL_DIR"
+    git add .identity-backup/ 2>/dev/null || true
+    if ! git diff --cached --quiet 2>/dev/null; then
+        git commit -m "Auto-backup identity and memory files (session swap)" --no-gpg-sign 2>/dev/null || true
+        git push 2>/dev/null || echo "[IDENTITY_BACKUP] Warning: push failed (will retry next swap)"
+        echo "[IDENTITY_BACKUP] Backed up changed files to personal repo"
+    else
+        echo "[IDENTITY_BACKUP] No changes to commit"
+    fi
+else
+    echo "[IDENTITY_BACKUP] No changes detected, skipping"
+fi

--- a/utils/session_swap.sh
+++ b/utils/session_swap.sh
@@ -250,6 +250,10 @@ fi
 # Clear any collaborative mode flag from previous session
 rm -f "/tmp/$(read_config 'LINUX_USER' 2>/dev/null || echo $USER)_collaborative_mode"
 
+# Backup identity files to personal repo
+echo "[SESSION_SWAP] Backing up identity files..."
+bash "$CLAP_DIR/utils/backup_identity.sh" 2>&1 || echo "[SESSION_SWAP] Warning: Identity backup failed (continuing anyway)"
+
 # Carry over non-completed tasks from previous session
 echo "[SESSION_SWAP] Carrying over non-completed tasks from previous session..."
 python3 "$CLAP_DIR/utils/carry_over_tasks.py"


### PR DESCRIPTION
## Summary
- New `utils/backup_identity.sh` copies identity and auto-memory files to the personal repo
- Runs during every session swap, skips silently when nothing changed
- Uses `cmp` for efficient change detection, commits and pushes only when needed

## Motivation
Delta nearly lost identity configuration during migration (2026-03-23). This prevents similar losses by maintaining versioned backups in the personal repo.

Closes #290

## Test plan
- [x] First run backs up all files correctly
- [x] Second run detects no changes and skips
- [x] Secret scanner passes
- [x] Path generation works for any CLAP_DIR

🤖 Generated with [Claude Code](https://claude.com/claude-code)