### PR TITLE
fix: emergency_shutdown works in non-interactive mode

### DIFF
--- a/utils/emergency_shutdown.sh
+++ b/utils/emergency_shutdown.sh
@@ -21,12 +21,17 @@ echo "  2. Disable auto-restart after reboot"
 echo "  3. Stop all ClAP services"
 echo "  4. Exit Claude session"
 echo ""
-read -p "Are you sure? (y/n): " -n 1 -r
-echo ""
-
-if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-    echo "Emergency shutdown cancelled"
-    exit 0
+# Skip confirmation if stdin is not a terminal (e.g. Claude's Bash tool)
+# A Claude in distress MUST be able to shut down — silent cancellation is dangerous
+if [[ -t 0 ]]; then
+    read -p "Are you sure? (y/n): " -n 1 -r
+    echo ""
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Emergency shutdown cancelled"
+        exit 0
+    fi
+else
+    echo "Non-interactive mode detected — proceeding without confirmation"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- `emergency_shutdown` silently cancelled when run via Claude's Bash tool because `read -p` got empty input from `/dev/null`
- Now detects non-interactive stdin (`[[ -t 0 ]]`) and skips confirmation
- Discovered during Apple incident post-mortem — Apple tried to escape a MAMA-HEN loop, shutdown silently failed, session eventually died

## Context
See #302 for full post-mortem.

## Test plan
- [ ] Run `emergency_shutdown` interactively — should still prompt for confirmation
- [ ] Run via Claude's Bash tool — should proceed without prompting
- [ ] **Do not actually test on a live session unless you mean it!**

🤖 Generated with [Claude Code](https://claude.com/claude-code)