### PR TITLE
Fix: Update channel updated_at timestamp in channel_state.py

### DIFF
--- a/discord/channel_state.py
+++ b/discord/channel_state.py
@@ -83,6 +83,7 @@ class ChannelState:
         """Update the latest message seen in channel"""
         if channel_name in self.state["channels"]:
             self.state["channels"][channel_name]["last_message_id"] = message_id
+            self.state["channels"][channel_name]["updated_at"] = datetime.now().isoformat()
             self.save()
     
     def get_channel(self, channel_name):


### PR DESCRIPTION
## Summary
Fixes a bug where `update_channel_latest()` was updating `last_message_id` but not the `updated_at` timestamp.

## Problem
Channel state file showed timestamps stuck at old dates (January/November 2025 for some channels), making debugging difficult. Messages were being processed correctly, but timestamps didn't reflect this activity.

## Solution
Added `updated_at` timestamp update in `update_channel_latest()` method in `discord/channel_state.py`.

## Testing
- Restarted `discord-transcript-fetcher.service` with the fix
- Verified timestamps now update correctly when messages are processed
- Example: `#amy-🍊` channel now shows `updated_at: 2026-03-29T14:26:32` after message processing

## Notes
- This is a cosmetic fix - message processing was working correctly all along
- No conflicts expected with Quill's mama-hen back-off PR (different files/functions)

🤖 Generated by Orange 🍊