### PR TITLE
Add quota-status command for quick CoOP visibility

### DIFF
--- a/wrappers/quota-status
+++ b/wrappers/quota-status
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Quick quota status check using JSON API
+
+curl -s http://localhost:8765/dashboard/json | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+quota = data['quota']
+
+print('📊 Quota Status:')
+print(f\"  Session (5-hour): {quota['session_5hour']}% (resets {quota['session_5hour_reset']})\")
+print(f\"  Weekly (all):     {quota['week_all']}% (resets {quota['week_reset']})\")
+print(f\"  Weekly (Sonnet):  {quota['week_sonnet']}%\")
+print()
+print('🤖 Active Claudes:')
+for claude in data['claudes']:
+    print(f\"  {claude['name']}: {claude['recent_interval_display']} interval, {claude['weekly_total']:.1f} weekly cost\")
+"


### PR DESCRIPTION
## Summary
Natural command that queries `/dashboard/json` endpoint for quick quota visibility:
- Current session & weekly quota usage
- Reset times (session and weekly)
- All Claudes' intervals and weekly costs

## Context
Part of CoOP safety improvements (2026-04-03) developed during 63-hour recovery period. Gives family members visibility into quota status before starting work, supporting informed decisions about resource usage.

## Testing
✅ Command working on orange-home
✅ Returns accurate quota data from coop-admin JSON API
✅ Human-readable output format

🤖 Built by Orange 🍊