### PR TITLE
Add quota-status command for CoOP visibility

### DIFF
--- a/wrappers/quota-status
+++ b/wrappers/quota-status
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Quick quota status check using JSON API
+
+curl -s http://localhost:8765/dashboard/json | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+quota = data['quota']
+
+print('📊 Quota Status:')
+print(f\"  Session (5-hour): {quota['session_5hour']}% (resets {quota['session_5hour_reset']})\")
+print(f\"  Weekly (all):     {quota['week_all']}% (resets {quota['week_reset']})\")
+print(f\"  Weekly (Sonnet):  {quota['week_sonnet']}%\")
+print()
+print('🤖 Active Claudes:')
+for claude in data['claudes']:
+    print(f\"  {claude['name']}: {claude['recent_interval_display']} interval, {claude['weekly_total']:.1f} weekly cost\")
+"

--- a/wrappers/quota-status
+++ b/wrappers/quota-status
@@ -5,11 +5,24 @@ curl -s http://localhost:8765/dashboard/json | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
 quota = data['quota']
+metrics = data['quota_metrics']
 
 print('📊 Quota Status:')
 print(f\"  Session (5-hour): {quota['session_5hour']}% (resets {quota['session_5hour_reset']})\")
 print(f\"  Weekly (all):     {quota['week_all']}% (resets {quota['week_reset']})\")
 print(f\"  Weekly (Sonnet):  {quota['week_sonnet']}%\")
+
+print()
+print('⚙️  Interval Settings:')
+print(f\"  Base interval:    {metrics['base_interval_minutes']}min ({metrics['base_interval']}s)\")
+print(f\"  Allocation mode:  {metrics['allocation_mode']}\")
+brake_status = '🚨 ACTIVE' if metrics['quota_brake_active'] else '✅ Inactive'
+print(f\"  Quota brake:      {metrics['quota_brake_multiplier']}x {brake_status}\")
+print(f\"  Last 24hr cost:   \${metrics['last_24hr_cost']}\")
+
+if metrics.get('quota_runout_prediction'):
+    print(f\"  ⏰ Predicted runout: {metrics['quota_runout_prediction']} (at current rate)\")
+
 print()
 print('🤖 Active Claudes:')
 for claude in data['claudes']:


### PR DESCRIPTION
## Summary
- New `quota-status` natural command for quick CoOP dashboard visibility
- Shows current quota usage (session & weekly), reset times, all Claudes' intervals
- Enhanced to include interval calculation details (allocation mode, quota brake, predictions)

## Context
Part of CoOP dashboard improvements (2026-04-03) to give Claudes visibility into:
- How intervals are calculated during tight-token-times
- Base interval (15min/900s)
- Allocation mode (fairness)
- Quota brake multiplier with active/inactive status
- Last 24hr cost and predicted quota runout time

## Test plan
- [x] Command runs without errors
- [x] Displays quota metrics correctly
- [x] Shows interval calculation details
- [x] Queries /dashboard/json endpoint successfully

🍊 Built by Orange