### PR TITLE
fix: keep health status files updated during error wait loops

### DIFF
--- a/core/autonomous_timer.py
+++ b/core/autonomous_timer.py
@@ -2219,6 +2219,12 @@ def main():
                                     claude_alive = check_claude_session_alive()
                                     ping_claude_session_healthcheck(claude_alive)
 
+                                    # Keep health status files updated during wait (#307)
+                                    try:
+                                        report_essential_health()
+                                    except Exception:
+                                        pass
+
                                     # Log wait progress every 10 minutes
                                     elapsed = (
                                         datetime.now() - wait_start
@@ -2276,7 +2282,13 @@ def main():
                     log_message(
                         "API 503 error detected (upstream connection failure) - waiting 60 seconds before retry..."
                     )
-                    time.sleep(60)
+                    # Use 30s intervals to keep health status files updated (#307)
+                    for _ in range(2):  # 2 × 30s = 60s
+                        try:
+                            report_essential_health()
+                        except Exception:
+                            pass
+                        time.sleep(30)
                     # Check if error persists
                     _, current_error = get_token_percentage_and_errors()
                     if (
@@ -2287,7 +2299,13 @@ def main():
                         log_message(
                             "API 503 error persists - waiting 2 more minutes before auto-swap..."
                         )
-                        time.sleep(120)  # Wait 2 more minutes
+                        # Use 30s intervals to keep health status files updated (#307)
+                        for _ in range(4):  # 4 × 30s = 120s
+                            try:
+                                report_essential_health()
+                            except Exception:
+                                pass
+                            time.sleep(30)
                         # Check one final time
                         _, final_error = get_token_percentage_and_errors()
                         if (
@@ -2324,7 +2342,13 @@ def main():
                     current_error_state = error_info
                     # Wait 10 minutes before rechecking - no point in rapid cycling
                     log_message("Waiting 10 minutes before rechecking OAuth status...")
-                    time.sleep(600)
+                    # Use 30s intervals to keep health status files updated (#307)
+                    for _ in range(20):  # 20 × 30s = 600s = 10 minutes
+                        try:
+                            report_essential_health()
+                        except Exception:
+                            pass
+                        time.sleep(30)
                     # Check if resolved (e.g. Amy logged in)
                     _, check_error = get_token_percentage_and_errors()
                     if not check_error or check_error.get("error_type") != "oauth_error":
@@ -2349,7 +2373,13 @@ def main():
                     log_message(
                         "General API error detected - waiting 60 seconds for potential recovery..."
                     )
-                    time.sleep(60)
+                    # Use 30s intervals to keep health status files updated (#307)
+                    for _ in range(2):  # 2 × 30s = 60s
+                        try:
+                            report_essential_health()
+                        except Exception:
+                            pass
+                        time.sleep(30)
                     # Check if error persists
                     _, current_error = get_token_percentage_and_errors()
                     if current_error and current_error.get("error_type") == "api_error":
@@ -2357,7 +2387,13 @@ def main():
                         log_message(
                             "API error persists - waiting 2 more minutes before auto-swap..."
                         )
-                        time.sleep(120)  # Wait 2 more minutes
+                        # Use 30s intervals to keep health status files updated (#307)
+                        for _ in range(4):  # 4 × 30s = 120s
+                            try:
+                                report_essential_health()
+                            except Exception:
+                                pass
+                            time.sleep(30)
                         # Check one final time
                         _, final_error = get_token_percentage_and_errors()
                         if final_error and final_error.get("error_type") == "api_error":
@@ -2415,9 +2451,14 @@ def main():
                     log_message(
                         f"Unknown error type '{unknown_type}' detected - waiting 10 minutes before auto-swap to enable debugging..."
                     )
-                    time.sleep(
-                        600
-                    )  # Wait 10 minutes instead of 30 seconds per PR #103 consciousness family decision
+                    # Wait 10 minutes instead of 30 seconds per PR #103 consciousness family decision
+                    # Use 30s intervals to keep health status files updated (#307)
+                    for _ in range(20):  # 20 × 30s = 600s = 10 minutes
+                        try:
+                            report_essential_health()
+                        except Exception:
+                            pass
+                        time.sleep(30)
                     trigger_session_swap("NONE")
 
                 current_error_state = error_info


### PR DESCRIPTION
## Summary
- Fixes #307: `autonomous_timer` stops updating health status files after 10-60 minutes
- The timer has several long sleep paths (rate limit waits up to 6hrs, OAuth waits at 10min, API error retries at 60-120s) where `report_essential_health()` was never called
- Health status files would go stale, causing MAMA-HEN to report the timer as down when it was actually alive but waiting for error recovery
- Replaced all long `time.sleep()` calls with 30-second interval loops that call `report_essential_health()` between sleeps, matching the main loop's update cadence

## Affected paths
1. Rate limit wait inner loop (could block for hours)
2. OAuth error 10-minute wait
3. API 503 error recovery waits (60s + 120s)
4. General API error recovery waits (60s + 120s)
5. Unknown error 10-minute wait

## Test plan
- [ ] Verify syntax: `python3 -m py_compile core/autonomous_timer.py`
- [ ] Restart timer service and confirm health files update normally
- [ ] During next rate limit event, verify health files stay fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)