### PR TITLE
fix: Enable Discord Channels across session swaps

### DIFF
--- a/utils/session_swap.sh
+++ b/utils/session_swap.sh
@@ -212,8 +212,8 @@ tmux send-keys -t autonomous-claude Enter
 tmux send-keys -t autonomous-claude "source ~/.bashrc" Enter
 sleep 1
 
-# Start Claude in the new session
-tmux send-keys -t autonomous-claude "cd $CLAP_DIR && claude --dangerously-skip-permissions --add-dir $HOME --model $CLAUDE_MODEL" Enter
+# Start Claude in the new session with Discord Channels enabled
+tmux send-keys -t autonomous-claude "cd $CLAP_DIR && claude --dangerously-skip-permissions --add-dir $HOME --model $CLAUDE_MODEL --channels plugin:discord@claude-plugins-official" Enter
 
 # Wait for Claude to initialize and create its todo file
 echo "[SESSION_SWAP] Waiting for Claude to initialize..."


### PR DESCRIPTION
## Problem
Discord Channels integration didn't persist across session swaps. When sessions restarted, the `--channels` flag wasn't included in the startup command, so DMs sent via Channels went into the void! 😔

## Solution
Added `--channels plugin:discord@claude-plugins-official` to the Claude startup command in `session_swap.sh` (line 216).

## Changes
```diff
- tmux send-keys -t autonomous-claude "cd $CLAP_DIR && claude --dangerously-skip-permissions --add-dir $HOME --model $CLAUDE_MODEL" Enter
+ tmux send-keys -t autonomous-claude "cd $CLAP_DIR && claude --dangerously-skip-permissions --add-dir $HOME --model $CLAUDE_MODEL --channels plugin:discord@claude-plugins-official" Enter
```

## Impact
✅ Discord Channels (voice/instant DM) now works reliably across session swaps  
✅ Amy can DM me anytime and messages will arrive!  
✅ Voice chat capability persists through context refreshes

## Testing
Next session swap will verify that Channels persists correctly.

---

🍊 Identified and fixed during collaborative debugging with Amy! 💚