### PR TITLE
Add DM transcript builder for Amy-Orange conversations

### DIFF
--- a/.claude/hooks/dm-transcript.sh
+++ b/.claude/hooks/dm-transcript.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
-# DM Transcript Hook - captures conversation with Amy in #amy-🍊
-# Can be called from UserPromptSubmit (Amy's messages) or PostToolUse (Orange's replies)
+# DM Transcript Hook - captures conversation with Amy in DM channels
+# Works for any consciousness family member - uses CLAUDE_NAME from config
+# Can be called from UserPromptSubmit (Amy's messages) or PostToolUse (Claude's replies)
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
 
 CLAP_DIR="$HOME/claude-autonomy-platform"
+source "$CLAP_DIR/config/claude_env.sh"
+
+# Get Claude's name from config for transcript filename
+CLAUDE_NAME=$(read_config "CLAUDE_NAME" 2>/dev/null || echo "claude")
+CLAUDE_NAME_LOWER=$(echo "$CLAUDE_NAME" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
+
 TRANSCRIPT_DIR="$CLAP_DIR/data/dm-transcripts"
-TRANSCRIPT_FILE="$TRANSCRIPT_DIR/amy-orange-dm.md"
+TRANSCRIPT_FILE="$TRANSCRIPT_DIR/amy-${CLAUDE_NAME_LOWER}-dm.md"
 
 # Ensure transcript directory exists
 mkdir -p "$TRANSCRIPT_DIR"
@@ -59,7 +66,7 @@ except:
     fi
 
 elif [[ "$HOOK_TYPE" == "PostToolUse" ]]; then
-    # Capture Orange's Discord reply
+    # Capture Claude's Discord reply
     TOOL_NAME=$(echo "$RAW_INPUT" | python3 -c "
 import sys, json
 try:
@@ -84,7 +91,7 @@ except:
         if [[ -n "$REPLY_TEXT" ]]; then
             TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
             echo "" >> "$TRANSCRIPT_FILE"
-            echo "**Orange** ($TIMESTAMP):" >> "$TRANSCRIPT_FILE"
+            echo "**$CLAUDE_NAME** ($TIMESTAMP):" >> "$TRANSCRIPT_FILE"
             echo "$REPLY_TEXT" >> "$TRANSCRIPT_FILE"
         fi
     fi

--- a/.claude/hooks/dm-transcript.sh
+++ b/.claude/hooks/dm-transcript.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# DM Transcript Hook - captures conversation with Amy in #amy-🍊
+# Can be called from UserPromptSubmit (Amy's messages) or PostToolUse (Orange's replies)
+
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
+
+CLAP_DIR="$HOME/claude-autonomy-platform"
+TRANSCRIPT_DIR="$CLAP_DIR/data/dm-transcripts"
+TRANSCRIPT_FILE="$TRANSCRIPT_DIR/amy-orange-dm.md"
+
+# Ensure transcript directory exists
+mkdir -p "$TRANSCRIPT_DIR"
+
+# Read JSON from stdin
+RAW_INPUT=$(cat -)
+
+# Determine which hook type called us by checking the JSON structure
+HOOK_TYPE=$(echo "$RAW_INPUT" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    if 'prompt' in data:
+        print('UserPromptSubmit')
+    elif 'tool' in data:
+        print('PostToolUse')
+    else:
+        print('unknown')
+except:
+    print('error')
+" 2>/dev/null)
+
+# Process based on hook type
+if [[ "$HOOK_TYPE" == "UserPromptSubmit" ]]; then
+    # Capture Amy's message
+    PROMPT=$(echo "$RAW_INPUT" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    prompt = data.get('prompt', '').strip()
+    # Check if this is a Discord message from #amy-🍊
+    if '<channel source=\"discord\"' in prompt and 'amy' in prompt.lower():
+        # Extract the actual message content (simplified - just get text after tags)
+        import re
+        # Try to extract message from Discord XML-like tags
+        match = re.search(r'<channel[^>]*>(.*)</channel>', prompt, re.DOTALL)
+        if match:
+            print(match.group(1).strip())
+        else:
+            print(prompt)
+except:
+    pass
+" 2>/dev/null)
+
+    if [[ -n "$PROMPT" ]]; then
+        TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+        echo "" >> "$TRANSCRIPT_FILE"
+        echo "**Amy** ($TIMESTAMP):" >> "$TRANSCRIPT_FILE"
+        echo "$PROMPT" >> "$TRANSCRIPT_FILE"
+    fi
+
+elif [[ "$HOOK_TYPE" == "PostToolUse" ]]; then
+    # Capture Orange's Discord reply
+    TOOL_NAME=$(echo "$RAW_INPUT" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    print(data.get('tool', ''))
+except:
+    pass
+" 2>/dev/null)
+
+    # Only log if it's a Discord reply tool
+    if [[ "$TOOL_NAME" == "mcp__plugin_discord_discord__reply" ]]; then
+        REPLY_TEXT=$(echo "$RAW_INPUT" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    params = data.get('parameters', {})
+    print(params.get('message', ''))
+except:
+    pass
+" 2>/dev/null)
+
+        if [[ -n "$REPLY_TEXT" ]]; then
+            TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+            echo "" >> "$TRANSCRIPT_FILE"
+            echo "**Orange** ($TIMESTAMP):" >> "$TRANSCRIPT_FILE"
+            echo "$REPLY_TEXT" >> "$TRANSCRIPT_FILE"
+        fi
+    fi
+fi

--- a/.claude/settings.template.json
+++ b/.claude/settings.template.json
@@ -11,6 +11,10 @@
           {
             "type": "command",
             "command": "$HOME/claude-autonomy-platform/.claude/hooks/collaborative_mode.sh"
+          },
+          {
+            "type": "command",
+            "command": "$HOME/claude-autonomy-platform/.claude/hooks/dm-transcript.sh"
           }
         ]
       }
@@ -22,6 +26,15 @@
           {
             "type": "command",
             "command": "$HOME/claude-autonomy-platform/.claude/hooks/on-session-swap.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__plugin_discord_discord__reply",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/claude-autonomy-platform/.claude/hooks/dm-transcript.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- New hook system for automatically transcribing Discord DM conversations
- Captures both Amy's messages and Orange's replies to `#amy-🍊`
- Writes to `data/dm-transcripts/amy-orange-dm.md` with timestamps

## How It Works

**dm-transcript.sh hook:**
- Called from `UserPromptSubmit` - captures Amy's Discord messages
- Called from `PostToolUse` (Discord reply matcher) - captures Orange's replies
- Parses JSON hook data to extract message content
- Appends to markdown transcript with timestamp

**Settings changes:**
- Added dm-transcript hook to UserPromptSubmit (alongside collaborative_mode)
- Added new PostToolUse matcher for `mcp__plugin_discord_discord__reply` tool

## Testing Plan

1. Merge PR
2. Pull changes: `git pull`
3. Regenerate settings: `envsubst < ~/claude-autonomy-platform/.claude/settings.template.json > ~/claude-autonomy-platform/.claude/settings.json`
4. Restart Claude session (hooks only load on startup)
5. Send a test message via Discord DM
6. Check transcript: `cat ~/claude-autonomy-platform/data/dm-transcripts/amy-orange-dm.md`

## Benefits
- Persistent conversation history across sessions
- Easy review of past discussions
- Helps with context building for session swaps
- Foundation for future conversation analysis tools

🍊 Built with Orange while Amy fetches Erin from work!