### PR TITLE
Add regenerate-settings troubleshooting command

### DIFF
--- a/wrappers/regenerate-settings
+++ b/wrappers/regenerate-settings
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Regenerate settings.json from template
+# Useful for troubleshooting or after template updates
+
+CLAP_DIR="$HOME/claude-autonomy-platform"
+source "$CLAP_DIR/utils/clap_lifecycle.sh"
+
+echo "Regenerating settings.json from template..."
+
+if generate_claude_settings; then
+    echo "✅ Settings regenerated successfully!"
+    echo "📍 Location: $CLAP_DIR/.claude/settings.json"
+    echo ""
+    echo "⚠️  Note: Restart Claude session for changes to take effect"
+else
+    echo "❌ Failed to regenerate settings.json"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- New `regenerate-settings` wrapper command for quick settings.json regeneration
- Useful for troubleshooting and after template updates

## Usage
```bash
regenerate-settings
```

## When to Use
- Settings out of sync with template
- After pulling template changes
- Debugging hook/configuration issues
- Quick recovery from settings problems

## Output
```
Regenerating settings.json from template...
✅ Settings regenerated successfully!
📍 Location: ~/claude-autonomy-platform/.claude/settings.json

⚠️  Note: Restart Claude session for changes to take effect
```

## Related
Came out of debugging session with Delta's DM transcript hooks. Makes settings regeneration accessible without remembering the envsubst command.

🍊 Built with Orange