### PR TITLE
Fix context check crashing on null statusline values

### DIFF
--- a/utils/check_context.py
+++ b/utils/check_context.py
@@ -76,9 +76,9 @@ def check_context(return_data=False):
         print(error_msg)
         return None
 
-    # Extract context window data
-    context_window = statusline.get("context_window", {})
-    current_usage = context_window.get("current_usage", {})
+    # Extract context window data (use 'or {}' to handle None values)
+    context_window = statusline.get("context_window") or {}
+    current_usage = context_window.get("current_usage") or {}
 
     # Cache read tokens = the main session context size
     cache_tokens = current_usage.get("cache_read_input_tokens", 0)


### PR DESCRIPTION
## Summary
- Fix `context` command crashing when statusline JSON has null values for context_window or current_usage
- Changed `.get(key, {})` to `.get(key) or {}` to handle both missing keys and explicit null values

## Test plan
- [x] Verified `context` command works after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)