### PR TITLE
Add /status to session startup to populate statusline

### DIFF
--- a/utils/clap_lifecycle.sh
+++ b/utils/clap_lifecycle.sh
@@ -252,6 +252,11 @@ start_claude_session() {
         send_to_claude "/color $session_color" 2>/dev/null || true
         sleep 2
     fi
+
+    # Trigger /status to populate statusline_data.json with session_id
+    if type send_to_claude &>/dev/null; then
+        send_to_claude "/status" 2>/dev/null || true
+    fi
 }
 
 # ─── Discord notification ────────────────────────────────────────


### PR DESCRIPTION
## Summary
- After starting Claude Code in `start_claude_session()`, send `/status` to trigger statusline.sh
- This populates `statusline_data.json` with session_id immediately, rather than waiting for the first API interaction

## Context
When clap-start launches Claude Code, monitoring tools (like `context`) may try to read statusline data before Claude has made any API calls. The data would be stale or have null values. Sending `/status` ensures the statusline is populated right away.

Complements PR #331 (null handling as defense-in-depth).

## Test plan
- [x] Verified `/status` populates statusline_data.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)