### PR TITLE
Add systemd watchdog to autonomous timer

### DIFF
--- a/core/autonomous_timer.py
+++ b/core/autonomous_timer.py
@@ -17,6 +17,7 @@ import sys
 import glob
 import re
 import signal
+import socket
 import collections
 import requests
 from datetime import datetime, timedelta
@@ -34,6 +35,21 @@ from utils.check_seeds import get_seed_reminder
 from utils.check_context import check_context
 from utils.check_usage import check_usage
 from utils.health_reporter import write_status
+
+
+def sd_notify(state):
+    """Send notification to systemd (watchdog/ready). No-op if not running under systemd."""
+    addr = os.environ.get("NOTIFY_SOCKET")
+    if not addr:
+        return
+    if addr[0] == "@":
+        addr = "\0" + addr[1:]
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    try:
+        sock.sendto(state.encode(), addr)
+    finally:
+        sock.close()
+
 
 # Configuration
 AUTONOMY_DIR = get_clap_dir()
@@ -2117,6 +2133,7 @@ def report_essential_health():
 def main():
     """Main timer loop"""
     log_message("=== Autonomous Timer Started ===")
+    sd_notify("READY=1")
 
     # Signal handlers so we log unexpected termination
     def handle_signal(signum, frame):
@@ -2669,7 +2686,7 @@ def main():
 
             # Channel monitor functionality is now integrated here
 
-            # Sleep for 30 seconds before next check (can be longer since we're doing simple string comparison)
+            sd_notify("WATCHDOG=1")
             time.sleep(30)
 
         except KeyboardInterrupt:
@@ -2677,7 +2694,8 @@ def main():
             break
         except Exception as e:
             log_message(f"Error in main loop: {e}")
-            time.sleep(30)  # Sleep longer on error
+            sd_notify("WATCHDOG=1")
+            time.sleep(30)
 
 
 if __name__ == "__main__":

--- a/systemd/autonomous-timer.service
+++ b/systemd/autonomous-timer.service
@@ -3,7 +3,9 @@ Description=Autonomous Timer for Claude
 After=network.target
 
 [Service]
-Type=simple
+Type=notify
+NotifyAccess=main
+WatchdogSec=120
 WorkingDirectory=%h/claude-autonomy-platform
 Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
 Environment=PYTHONPATH=%h/claude-autonomy-platform


### PR DESCRIPTION
## Summary
- Timer process was found alive but silently stuck for 2 days — no logging, no CoOP reporting, no autonomy prompts
- PID check couldn't detect this because the process existed but wasn't doing work
- Adds systemd watchdog: if the timer doesn't ping within 120s, systemd kills and restarts it
- Uses raw socket notify — no external Python dependency

## Test plan
- [x] Timer restarts cleanly with new service type
- [x] `systemctl --user show autonomous-timer | grep Watchdog` confirms WatchdogSec=2min
- [x] READY=1 notification works (systemd shows "Started" after timer init)
- [ ] Verify watchdog triggers restart on stuck process (hard to test without inducing a hang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)