### PR TITLE
Add systemd watchdog to all essential services

### DIFF
--- a/core/autonomous_timer.py
+++ b/core/autonomous_timer.py
@@ -32,6 +32,7 @@ from utils.infrastructure_config_reader import get_config_value
 from utils.track_activity import is_idle
 from utils.check_seeds import get_seed_reminder
 from utils.check_context import check_context
+from utils.systemd_notify import notify_ready, notify_watchdog
 from utils.check_usage import check_usage
 from utils.health_reporter import write_status
 
@@ -2117,6 +2118,7 @@ def report_essential_health():
 def main():
     """Main timer loop"""
     log_message("=== Autonomous Timer Started ===")
+    notify_ready()
 
     # Signal handlers so we log unexpected termination
     def handle_signal(signum, frame):
@@ -2669,7 +2671,7 @@ def main():
 
             # Channel monitor functionality is now integrated here
 
-            # Sleep for 30 seconds before next check (can be longer since we're doing simple string comparison)
+            notify_watchdog()
             time.sleep(30)
 
         except KeyboardInterrupt:
@@ -2677,7 +2679,8 @@ def main():
             break
         except Exception as e:
             log_message(f"Error in main loop: {e}")
-            time.sleep(30)  # Sleep longer on error
+            notify_watchdog()
+            time.sleep(30)
 
 
 if __name__ == "__main__":

--- a/core/session_swap_monitor.py
+++ b/core/session_swap_monitor.py
@@ -15,6 +15,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'utils'))
 from claude_paths import get_clap_dir
 from infrastructure_config_reader import get_config_value
 from clap_logger import get_logger
+from systemd_notify import notify_ready, notify_watchdog
 
 # Get dynamic paths
 clap_dir = get_clap_dir()
@@ -65,6 +66,7 @@ def ping_healthcheck():
 
 def main():
     logger.info("Session swap monitor service started")
+    notify_ready()
 
     # Ensure trigger file exists with default value
     if not TRIGGER_FILE.exists():
@@ -101,15 +103,16 @@ def main():
                 ping_healthcheck()
                 ping_counter = 0
 
-            # Sleep for a short interval
+            notify_watchdog()
             time.sleep(2)
-            
+
         except KeyboardInterrupt:
             logger.info("Service stopped by user")
             break
         except Exception as e:
             logger.error("Error in main loop: %s", e)
-            time.sleep(5)  # Sleep longer on error
+            notify_watchdog()
+            time.sleep(5)
 
 if __name__ == "__main__":
     main()

--- a/discord/claude_status_bot.py
+++ b/discord/claude_status_bot.py
@@ -17,6 +17,7 @@ import sys
 sys.path.append(str(Path(__file__).parent.parent / "utils"))
 from infrastructure_config_reader import get_config_value
 from clap_logger import get_logger
+from systemd_notify import notify_ready, notify_watchdog
 
 logger = get_logger("discord-status-bot")
 
@@ -42,6 +43,7 @@ class ClaudeStatusBot(discord.Client):
         # Start monitoring for changes
         self.status_monitor.start()
         logger.info("Status monitor started")
+        notify_ready()
         
     async def update_status_from_file(self):
         """Update status from the status file"""
@@ -106,9 +108,10 @@ class ClaudeStatusBot(discord.Client):
     @tasks.loop(seconds=5)
     async def status_monitor(self):
         """Monitor for status update requests"""
+        notify_watchdog()
         if not self.status_file.exists():
             return
-            
+
         try:
             # Check if status file has been updated
             stat = self.status_file.stat()

--- a/discord/discord_transcript_fetcher.py
+++ b/discord/discord_transcript_fetcher.py
@@ -36,6 +36,7 @@ from discord.channel_state import ChannelState
 from discord.discord_tools import DiscordTools
 from utils.infrastructure_config_reader import get_config_value
 from utils.clap_logger import get_logger
+from utils.systemd_notify import notify_ready, notify_watchdog
 
 logger = get_logger("discord-transcript-fetcher")
 
@@ -372,6 +373,7 @@ class TranscriptFetcher:
 
         # Initialize channels
         self.initialize_channels()
+        notify_ready()
 
         # Main monitoring loop
         while True:
@@ -379,7 +381,7 @@ class TranscriptFetcher:
                 for channel_name in self.channels_to_track:
                     self.process_channel(channel_name)
 
-                # Wait before next check
+                notify_watchdog()
                 time.sleep(CHECK_INTERVAL)
 
             except KeyboardInterrupt:
@@ -387,6 +389,7 @@ class TranscriptFetcher:
                 break
             except Exception as e:
                 logger.error("Error in main loop: %s", e)
+                notify_watchdog()
                 time.sleep(CHECK_INTERVAL)
 
 

--- a/systemd/autonomous-timer.service
+++ b/systemd/autonomous-timer.service
@@ -13,6 +13,7 @@ EnvironmentFile=-%h/claude-autonomy-platform/config/claude_infrastructure_config
 ExecStart=/usr/bin/python3 %h/claude-autonomy-platform/core/autonomous_timer.py
 Restart=always
 RestartSec=10
+WatchdogSec=120
 StandardOutput=journal
 StandardError=journal
 KillMode=process

--- a/systemd/discord-status-bot.service
+++ b/systemd/discord-status-bot.service
@@ -12,6 +12,7 @@ EnvironmentFile=-%h/claude-autonomy-platform/config/claude_infrastructure_config
 ExecStart=/usr/bin/python3 %h/claude-autonomy-platform/discord/claude_status_bot.py
 Restart=always
 RestartSec=10
+WatchdogSec=120
 StandardOutput=journal
 StandardError=journal
 KillMode=process

--- a/systemd/discord-transcript-fetcher.service
+++ b/systemd/discord-transcript-fetcher.service
@@ -9,6 +9,7 @@ Environment=PYTHONUNBUFFERED=1
 ExecStart=/usr/bin/python3 %h/claude-autonomy-platform/discord/discord_transcript_fetcher.py
 Restart=always
 RestartSec=10
+WatchdogSec=120
 
 # Logging
 StandardOutput=append:%h/claude-autonomy-platform/logs/transcript_fetcher.log

--- a/systemd/session-swap-monitor.service
+++ b/systemd/session-swap-monitor.service
@@ -12,6 +12,7 @@ EnvironmentFile=-%h/claude-autonomy-platform/config/claude_infrastructure_config
 ExecStart=/usr/bin/python3 %h/claude-autonomy-platform/core/session_swap_monitor.py
 Restart=always
 RestartSec=10
+WatchdogSec=30
 StandardOutput=journal
 StandardError=journal
 KillMode=process

--- a/utils/systemd_notify.py
+++ b/utils/systemd_notify.py
@@ -1,0 +1,25 @@
+"""Systemd watchdog notification via sd_notify protocol."""
+
+import os
+import socket
+
+
+def sd_notify(state: str):
+    """Send a notification to systemd. No-op if not running under systemd."""
+    addr = os.environ.get("NOTIFY_SOCKET")
+    if not addr:
+        return
+    if addr[0] == "@":
+        addr = "\0" + addr[1:]
+    with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as sock:
+        sock.sendto(state.encode(), addr)
+
+
+def notify_ready():
+    """Tell systemd the service has finished starting."""
+    sd_notify("READY=1")
+
+
+def notify_watchdog():
+    """Ping the systemd watchdog to prevent timeout restart."""
+    sd_notify("WATCHDOG=1")


### PR DESCRIPTION
## Summary
- Shared `utils/systemd_notify.py` provides sd_notify protocol (READY + WATCHDOG)
- All four essential services now have watchdog monitoring:
  - **autonomous-timer**: 120s timeout (30s loop)
  - **session-swap-monitor**: 30s timeout (2s polling)
  - **discord-status-bot**: 120s timeout (5s task loop)
  - **discord-transcript-fetcher**: 120s timeout (30s check interval)
- If any service gets stuck without completing a loop, systemd kills and restarts it
- Supersedes #344 (which only covered the timer)

## Test plan
- [x] All Python files parse clean
- [x] Service files have correct WatchdogSec values
- [ ] Verify services restart cleanly after deploy
- [ ] Verify watchdog pings visible in `systemctl --user show <service> | grep Watchdog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)