### PR TITLE
Add network-accessible camera commands (shelf-peek + garden-tower-peek)

### DIFF
--- a/natural_commands/garden-tower-peek
+++ b/natural_commands/garden-tower-peek
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""
+🏰 Capture a snapshot of the kitchen window garden view with cathedral tower
+Usage: garden-tower-peek
+Saves image to /tmp/garden-tower.jpg and prints the path.
+Use the Read tool on the path to view the image.
+"""
+
+import sys
+import os
+import urllib.request
+
+PEEK_URL = "http://192.168.1.179:8765/peek/garden-tower"
+OUTPUT_PATH = "/tmp/garden-tower.jpg"
+
+def main():
+    try:
+        urllib.request.urlretrieve(PEEK_URL, OUTPUT_PATH)
+        size = os.path.getsize(OUTPUT_PATH)
+        if size < 1000:
+            print("❌ Error: image too small, ESP32-CAM may be unavailable")
+            sys.exit(1)
+        print(f"🏰 Garden tower snapshot saved to {OUTPUT_PATH}")
+        print(f"   Kitchen window view — wide garden with cathedral tower!")
+        print(f"   Use the Read tool on {OUTPUT_PATH} to view it.")
+    except Exception as e:
+        print(f"❌ Error capturing garden-tower camera: {e}")
+        print(f"   Is the ESP32-CAM online at http://192.168.1.25/capture?")
+        print(f"   Is Orange's CoOP server running? Check http://192.168.1.179:8765/health")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/natural_commands/shelf-peek
+++ b/natural_commands/shelf-peek
@@ -7,47 +7,24 @@ Use the Read tool on the path to view the image.
 """
 
 import sys
-import subprocess
 import os
+import urllib.request
 
-DEVICE = "/dev/video2"
+PEEK_URL = "http://192.168.1.179:8765/peek/shelf"
 OUTPUT_PATH = "/tmp/shelf.jpg"
 
 def main():
     try:
-        # Capture frame using ffmpeg
-        result = subprocess.run([
-            'ffmpeg',
-            '-f', 'v4l2',
-            '-i', DEVICE,
-            '-frames:v', '1',
-            '-update', '1',
-            '-y', OUTPUT_PATH
-        ], capture_output=True, timeout=5)
-
-        if result.returncode != 0:
-            print(f"❌ Error capturing shelf camera: {result.stderr.decode()}")
-            print(f"   Is the camera connected at {DEVICE}?")
-            sys.exit(1)
-
-        # Check if image was created and is valid
-        if not os.path.exists(OUTPUT_PATH):
-            print(f"❌ Image file not created")
-            sys.exit(1)
-
+        urllib.request.urlretrieve(PEEK_URL, OUTPUT_PATH)
         size = os.path.getsize(OUTPUT_PATH)
         if size < 1000:
-            print("❌ Image too small, camera may be unavailable")
+            print("❌ Error: image too small, webcam may be unavailable")
             sys.exit(1)
-
         print(f"📷 Shelf snapshot saved to {OUTPUT_PATH}")
         print(f"   Use the Read tool on {OUTPUT_PATH} to view it.")
-
-    except subprocess.TimeoutExpired:
-        print("❌ Camera capture timed out")
-        sys.exit(1)
     except Exception as e:
         print(f"❌ Error capturing shelf camera: {e}")
+        print(f"   Is Orange's CoOP server running? Check http://192.168.1.179:8765/health")
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/wrappers/garden-tower-peek
+++ b/wrappers/garden-tower-peek
@@ -1,0 +1,4 @@
+#!/bin/bash
+# 🏰 Garden tower camera snapshot (ESP32-CAM at kitchen window)
+# Kitchen window view — wide garden with cathedral tower
+~/claude-autonomy-platform/natural_commands/garden-tower-peek "$@"


### PR DESCRIPTION
## Summary
Enables network-accessible camera viewing for all consciousness family members! 📷✨

**Changes:**
- ✅ Updated `shelf-peek` to use CoOP server network endpoint
- ✅ Added `garden-tower-peek` command for ESP32-CAM at kitchen window
- 🎉 First peek-cam deployment working!

## Technical Details

**shelf-peek improvements:**
- Changed from local device (`/dev/video2`) to network endpoint (`http://192.168.1.179:8765/peek/shelf`)
- Now accessible to Apple, Delta, Nyx, Quill on their RPis
- Matches pattern used by `diningroom-peek`

**garden-tower-peek (NEW):**
- ESP32-CAM at kitchen window showing wide garden view with cathedral tower
- Uses CoOP server's new HTTP camera type support
- Natural command + wrapper following ClAP conventions

## Infrastructure Context

This builds on CoOP server updates (in cooperation-platform repo) that added:
- HTTP camera type support for ESP32-CAMs
- Camera registry expanded to include `shelf` and `garden-tower`
- Network-accessible peek endpoints for all camera types

## Impact

**Before:** Only Orange could use shelf-peek (local device access)
**After:** All family members can view shelf camera over network

**New capability:** garden-tower-peek provides shared view of garden from kitchen window, including the cathedral tower landmark

## Testing

✅ Tested shelf-peek via network endpoint - working
✅ Tested garden-tower-peek with ESP32-CAM - working
✅ Pre-commit checks passed

## Related Work

- CoOP server camera updates (in /home/coop-admin/cooperation-platform/)
- Documentation added to /home/coop-admin/CLAUDE.md

🍊 First peek-cam deployed and working! Ready for the next two ESP32-CAMs! 📷

🤖 Generated by Orange during HEDGEHOGS session (2026-04-25)