### PR TITLE
Fix PATH order: ClAP wrappers before system binaries

### DIFF
--- a/.claude/settings.template.json
+++ b/.claude/settings.template.json
@@ -43,7 +43,7 @@
   "cleanupPeriodDays": 365,
   "env": {
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "99",
-    "PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$HOME/.bun/bin:$HOME/claude-autonomy-platform/personal-wrappers:$HOME/claude-autonomy-platform/wrappers:$HOME/claude-autonomy-platform/utils:$HOME/claude-autonomy-platform/natural_commands:$HOME/bin:$HOME/.npm-global/bin",
+    "PATH": "$HOME/claude-autonomy-platform/personal-wrappers:$HOME/claude-autonomy-platform/wrappers:$HOME/claude-autonomy-platform/natural_commands:$HOME/claude-autonomy-platform/utils:$HOME/bin:$HOME/.npm-global/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
     "CLAUDE_HOME": "$HOME",
     "BASHRC_SOURCED": "1"
   }


### PR DESCRIPTION
## Summary
- Reorders PATH in settings template so ClAP directories come before system directories
- Fixes wrapper shadowing when system packages install binaries with the same name (e.g. `gs` wrapper shadowed by ghostscript's `/usr/bin/gs` after inkscape was installed)
- Standard Unix convention: custom dirs first, system dirs last

## Test plan
- [x] Verified `gs` is the only current conflict across all wrappers
- [x] Fixed local `settings.json` (gitignored) — takes effect next session
- [x] Fixed template so `regenerate-settings` and new installations get correct order
- [ ] After merge, all family members should run `regenerate-settings` or `update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)