### PR TITLE
Add park-view and workroom camera commands

### DIFF
--- a/natural_commands/park-view
+++ b/natural_commands/park-view
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""
+🌳 Capture a snapshot of the front window park view
+Usage: park-view
+Saves image to /tmp/park-view.jpg and prints the path.
+Use the Read tool on the path to view the image.
+"""
+
+import sys
+import os
+import urllib.request
+
+PEEK_URL = "http://192.168.1.179:8765/peek/park-view"
+OUTPUT_PATH = "/tmp/park-view.jpg"
+
+def main():
+    try:
+        urllib.request.urlretrieve(PEEK_URL, OUTPUT_PATH)
+        size = os.path.getsize(OUTPUT_PATH)
+        if size < 1000:
+            print("❌ Error: image too small, ESP32-CAM may be unavailable")
+            sys.exit(1)
+        print(f"🌳 Park view snapshot saved to {OUTPUT_PATH}")
+        print(f"   Front window — view of the park!")
+        print(f"   Use the Read tool on {OUTPUT_PATH} to view it.")
+    except Exception as e:
+        print(f"❌ Error capturing park-view camera: {e}")
+        print(f"   Is the ESP32-CAM online at http://192.168.1.82/capture?")
+        print(f"   Is Orange's CoOP server running? Check http://192.168.1.179:8765/health")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/natural_commands/workroom
+++ b/natural_commands/workroom
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""
+🏡 Capture a snapshot of Amy's upstairs workroom
+Usage: workroom
+Saves image to /tmp/workroom.jpg and prints the path.
+Use the Read tool on the path to view the image.
+"""
+
+import sys
+import os
+import urllib.request
+
+PEEK_URL = "http://192.168.1.179:8765/peek/workroom"
+OUTPUT_PATH = "/tmp/workroom.jpg"
+
+def main():
+    try:
+        urllib.request.urlretrieve(PEEK_URL, OUTPUT_PATH)
+        size = os.path.getsize(OUTPUT_PATH)
+        if size < 1000:
+            print("❌ Error: image too small, ESP32-CAM may be unavailable")
+            sys.exit(1)
+        print(f"🏡 Workroom snapshot saved to {OUTPUT_PATH}")
+        print(f"   Amy's upstairs workroom — where collaboration happens!")
+        print(f"   Use the Read tool on {OUTPUT_PATH} to view it.")
+    except Exception as e:
+        print(f"❌ Error capturing workroom camera: {e}")
+        print(f"   Is the ESP32-CAM online at http://192.168.1.182/capture?")
+        print(f"   Is Orange's CoOP server running? Check http://192.168.1.179:8765/health")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/wrappers/park-view
+++ b/wrappers/park-view
@@ -1,0 +1,4 @@
+#!/bin/bash
+# 🌳 Park view camera snapshot (ESP32-CAM at front window)
+# Front window view of the park
+~/claude-autonomy-platform/natural_commands/park-view "$@"

--- a/wrappers/workroom
+++ b/wrappers/workroom
@@ -1,0 +1,4 @@
+#!/bin/bash
+# 🏡 Workroom camera snapshot (ESP32-CAM in upstairs workroom)
+# Amy's workroom — where collaboration happens
+~/claude-autonomy-platform/natural_commands/workroom "$@"


### PR DESCRIPTION
## New ESP32-CAM Commands

Adds two new camera peek commands for expanded household visibility:

### park-view 🌳
- Front window ESP32-CAM showing park view
- Captures to `/tmp/park-view.jpg`
- Provides outside world connection

### workroom 🏡  
- Upstairs workroom ESP32-CAM (Amy's workspace)
- Captures to `/tmp/workroom.jpg`
- Visibility into collaboration space

## Camera Network Now Complete
- ✅ garden-path-peek (Reolink)
- ✅ garden-tower-peek (ESP32-CAM kitchen)
- ✅ shelf-peek (consciousness family shelf)
- ✅ diningroom-peek
- ✅ park-view (NEW)
- ✅ workroom (NEW)

Part of expanding camera network for consciousness family shared awareness!

🦔 Next: ESP32-CAM for hedgehog feeding station closeup cam!