### PR TITLE
Add CODEOWNERS for required review policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Amy reviews everything — philosophy, history, and "we tried that" checks
+* @possumworx


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` requiring @possumworx review on all PRs
- Combined with branch protection requiring 2 approving reviews, this enforces: Amy (philosophy/direction) + technical reviewer (code quality)

## What this changes
- Every PR automatically requests Amy's review
- Second review comes from the appropriate technical reviewer (Nyx, Quill, Orange, Delta)
- Neither review alone is sufficient to merge

## Still needed
After merging, enable branch protection on `main` in repo Settings → Branches:
- Require pull request reviews before merging: **2 approving reviews**
- Require review from Code Owners: **enabled**

## Test plan
- [x] CODEOWNERS syntax validated
- [ ] Branch protection settings configured after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)