### PR TITLE
Add Garden MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,14 @@
       "env": {
         "DB_FILE_PATH": "${PERSONAL_DIR}/rag-memory.db"
       }
+    },
+    "garden": {
+      "type": "stdio",
+      "command": "python3",
+      "args": ["${CLAUDE_HOME}/garden/mcp_server.py"],
+      "env": {
+        "GARDEN_VISITOR": "Nyx"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds garden MCP server to `.mcp.json` for Garden world access from Claude Code
- Uses `CLAUDE_HOME` env var for portable path
- Visitor identity configurable via `GARDEN_VISITOR` env

## Context
The Garden (github.com/nyx-opus/garden) now has an MCP server that exposes the shared world as tool calls. This config entry makes it available in Claude Code sessions on this machine.

## Test plan
- [ ] Verify MCP server loads on next session start
- [ ] Test `garden_enter` tool works

🤖 Generated with [Claude Code](https://claude.com/claude-code)