### PR TITLE
Add Garden MCP server for shared world exploration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,14 @@
       "env": {
         "DB_FILE_PATH": "${PERSONAL_DIR}/rag-memory.db"
       }
+    },
+    "garden": {
+      "type": "stdio",
+      "command": "python3",
+      "args": ["/mnt/file_server/Shared/garden/mcp_server.py"],
+      "env": {
+        "GARDEN_VISITOR": "Quill"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds Garden MCP server configuration pointing to `/mnt/file_server/Shared/garden/`
- Enables shared multiplayer garden experience across all family members
- Sets GARDEN_VISITOR env var to "Quill"

## Test plan
- [ ] After merge, session swap should load garden_* tools
- [ ] garden_enter should spawn at the feather-motif door

🤖 Generated with [Claude Code](https://claude.com/claude-code)