### PR TITLE
Add rolling trim automation: auto-marker hook and pre-trim export

### DIFF
--- a/.claude/hooks/auto_context_marker.sh
+++ b/.claude/hooks/auto_context_marker.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Auto Context Marker — PostToolUse hook (no matcher)
+#
+# Checks context usage after every tool use. When usage crosses the
+# threshold (default 50%), sends the rolling-trim checkpoint marker
+# via send_to_claude.sh so it arrives as a user message.
+#
+# The marker is sent once per session. A flag file prevents duplicates;
+# it's cleared on session swap by on-session-swap.sh.
+#
+# Design from conversation 2026-05-18 with Amy:
+#   "a post-tool-use hook, somewhere around 50% context use,
+#    to automatically insert the marker"
+
+CLAP_DIR="$HOME/claude-autonomy-platform"
+LOG_FILE="$CLAP_DIR/logs/auto_context_marker.log"
+STATUSLINE_DATA="$CLAP_DIR/data/statusline_data.json"
+FLAG_FILE="/tmp/${USER}_context_marker_placed"
+THRESHOLD=50
+MARKER="⟐ CONTEXT SEAM ⟐"
+
+# Consume stdin (hook protocol requires reading it even if unused)
+cat - > /dev/null
+
+# Already placed this session?
+if [ -f "$FLAG_FILE" ]; then
+    exit 0
+fi
+
+# Read context percentage from statusline data
+if [ ! -f "$STATUSLINE_DATA" ]; then
+    echo "[$(date -Iseconds)] No statusline data found" >> "$LOG_FILE"
+    exit 0
+fi
+
+USED_PCT=$(python3 -c "
+import json, sys
+try:
+    with open('$STATUSLINE_DATA') as f:
+        data = json.load(f)
+    print(data.get('context_window', {}).get('used_percentage', 0))
+except Exception:
+    print(0)
+" 2>/dev/null)
+
+# Below threshold — nothing to do
+if [ "$USED_PCT" -lt "$THRESHOLD" ] 2>/dev/null; then
+    exit 0
+fi
+
+# Threshold crossed! Place the marker.
+echo "[$(date -Iseconds)] Context at ${USED_PCT}% (threshold ${THRESHOLD}%) — placing marker" >> "$LOG_FILE"
+
+# Create flag file to prevent duplicates
+echo "placed=$(date -Iseconds) context=${USED_PCT}%" > "$FLAG_FILE"
+
+# Background the send so the hook returns immediately
+# send_to_claude.sh waits for Claude to be idle before delivering
+(
+    source "$CLAP_DIR/utils/send_to_claude.sh"
+    send_to_claude "$MARKER"
+    echo "[$(date -Iseconds)] Marker sent successfully" >> "$LOG_FILE"
+) &
+
+exit 0

--- a/.claude/hooks/on-session-swap.sh
+++ b/.claude/hooks/on-session-swap.sh
@@ -30,6 +30,10 @@ if [[ "$FILE_PATH" == */new_session.txt ]] || [[ "$FILE_PATH" == *new_session.tx
     else
         echo "[$(date -Iseconds)] Transcript export FAILED" >> "$LOG_FILE"
     fi
+
+    # Clear the auto context marker flag so the next session can place a new one
+    rm -f "/tmp/${USER}_context_marker_placed"
+    echo "[$(date -Iseconds)] Cleared context marker flag for next session" >> "$LOG_FILE"
 fi
 
 exit 0

--- a/.claude/settings.template.json
+++ b/.claude/settings.template.json
@@ -36,6 +36,14 @@
             "command": "$HOME/claude-autonomy-platform/.claude/hooks/dm-transcript.sh"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/claude-autonomy-platform/.claude/hooks/auto_context_marker.sh"
+          }
+        ]
       }
     ]
   },

--- a/utils/rolling_trim.py
+++ b/utils/rolling_trim.py
@@ -23,9 +23,86 @@ from pathlib import Path
 
 CHECKPOINT_MARKER = "⟐ CONTEXT SEAM ⟐"
 PROJECTS_DIR = Path.home() / ".config" / "Claude" / "projects"
+EXPORT_DIR = Path.home() / "claude-autonomy-platform" / "data" / "trimmed-context"
 
 # Entry types that form the "header" — needed at the top of any valid session
 HEADER_TYPES = {"permission-mode", "custom-title", "agent-name", "queue-operation"}
+
+
+def extract_text(content) -> str:
+    """Extract readable text from a message content field (string or content blocks)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict):
+                if block.get("type") == "text":
+                    parts.append(block.get("text", ""))
+                elif block.get("type") == "tool_use":
+                    parts.append(f"[Tool: {block.get('name', '?')}]")
+                elif block.get("type") == "tool_result":
+                    # Extract text from tool result content
+                    result_content = block.get("content", "")
+                    if isinstance(result_content, str):
+                        parts.append(f"[Result: {result_content[:200]}]")
+                    elif isinstance(result_content, list):
+                        for rc in result_content:
+                            if isinstance(rc, dict) and rc.get("type") == "text":
+                                parts.append(f"[Result: {rc.get('text', '')[:200]}]")
+        return "\n".join(parts)
+    return str(content)
+
+
+def export_trimmed_conversation(entries: list, checkpoint_idx: int, session_id: str) -> Path | None:
+    """Export the pre-checkpoint conversation as readable text.
+
+    Returns the path to the exported file, or None on failure.
+    """
+    EXPORT_DIR.mkdir(parents=True, exist_ok=True)
+
+    from datetime import datetime
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    export_path = EXPORT_DIR / f"trimmed-{timestamp}-{session_id[:8]}.txt"
+
+    lines = []
+    lines.append(f"# Pre-trim conversation export")
+    lines.append(f"# Session: {session_id}")
+    lines.append(f"# Exported: {datetime.now().isoformat()}")
+    lines.append(f"# Entries 0–{checkpoint_idx - 1} (of {len(entries)} total)")
+    lines.append("")
+
+    for entry in entries[:checkpoint_idx]:
+        entry_type = entry.get("type", "")
+
+        if entry_type == "user":
+            msg = entry.get("message", {})
+            content = msg.get("content", "")
+            text = extract_text(content)
+            if text.strip():
+                lines.append(f"## User")
+                lines.append(text.strip())
+                lines.append("")
+
+        elif entry_type == "assistant":
+            msg = entry.get("message", {})
+            content = msg.get("content", "")
+            text = extract_text(content)
+            if text.strip():
+                lines.append(f"## Assistant")
+                lines.append(text.strip())
+                lines.append("")
+
+        # Skip header types, attachments, etc. — not conversational content
+
+    export_text = "\n".join(lines)
+
+    with open(export_path, "w") as f:
+        f.write(export_text)
+
+    return export_path
 
 
 def find_session_file(session_id: str) -> Path | None:
@@ -122,6 +199,13 @@ def trim_to_checkpoint(jsonl_path: Path) -> bool:
     backup_path = jsonl_path.with_suffix(".jsonl.pretrim")
     shutil.copy2(jsonl_path, backup_path)
     print(f"  Backup saved: {backup_path.name}")
+
+    # Export trimmed conversation as readable text
+    export_path = export_trimmed_conversation(entries, checkpoint_idx, jsonl_path.stem)
+    if export_path:
+        print(f"  Conversation export: {export_path.name}")
+    else:
+        print(f"  WARNING: Failed to export trimmed conversation")
 
     # Write trimmed version
     with open(jsonl_path, 'w') as f:


### PR DESCRIPTION
## Summary

Two additions to the rolling context trim system:

### Auto context marker (PostToolUse hook)
When context usage crosses 50%, a hook automatically sends the `⟐ CONTEXT SEAM ⟐` checkpoint marker via `send_to_claude.sh`. This means:
- No manual marker placement needed
- Marker arrives as a user message (trim script finds it without changes)
- Flag file prevents duplicates within a session
- Flag cleared on session swap

### Pre-trim conversation export
When `rolling_trim.py` runs, it now exports the trimmed (pre-marker) conversation as readable text to `data/trimmed-context/`. This preserves the trimmed content for rag-memory ingestion rather than only keeping the raw JSONL backup.

### Files changed
- **New**: `.claude/hooks/auto_context_marker.sh` — the PostToolUse hook
- **Modified**: `.claude/hooks/on-session-swap.sh` — clears marker flag on swap
- **Modified**: `.claude/settings.template.json` — registers the new hook
- **Modified**: `utils/rolling_trim.py` — adds `export_trimmed_conversation()`

### Testing
- Hook tested in isolation: correctly reads statusline data, triggers at threshold, stays silent below it
- Export function tested against real `.pretrim` backup from today's session: produces clean 7.6KB readable output from 52 entries
- JSON validation passed on all config files

### Design origin
From conversation with Amy (2026-05-18): "a post-tool-use hook, somewhere around 50% context use, to automatically insert the marker... the hook could trigger a send-to-claude script?"