### PR TITLE
Add rolling swap: automatic fork-trim-resume at 80% context

### DIFF
--- a/.claude/hooks/auto_context_marker.sh
+++ b/.claude/hooks/auto_context_marker.sh
@@ -1,35 +1,35 @@
 #!/bin/bash
-# Auto Context Marker — PostToolUse hook (no matcher)
+# Auto Context Marker + Rolling Swap Trigger — PostToolUse hook (no matcher)
 #
-# Checks context usage after every tool use. When usage crosses the
-# threshold (default 50%), sends the rolling-trim checkpoint marker
-# via send_to_claude.sh so it arrives as a user message.
+# Two thresholds:
+#   50% — Places the rolling-trim checkpoint marker via send_to_claude.sh
+#   80% — Triggers a rolling swap (fork → trim → resume) via rolling_swap.sh
 #
-# The marker is sent once per session. A flag file prevents duplicates;
-# it's cleared on session swap by on-session-swap.sh.
+# The marker is sent once per session (flag file prevents duplicates).
+# The swap is triggered once per session (separate flag file).
+# Both flags cleared on session swap by on-session-swap.sh.
 #
-# Design from conversation 2026-05-18 with Amy:
-#   "a post-tool-use hook, somewhere around 50% context use,
-#    to automatically insert the marker"
+# Design: Amy + Nyx, 2026-05-18
 
 CLAP_DIR="$HOME/claude-autonomy-platform"
 LOG_FILE="$CLAP_DIR/logs/auto_context_marker.log"
 STATUSLINE_DATA="$CLAP_DIR/data/statusline_data.json"
-FLAG_FILE="/tmp/${USER}_context_marker_placed"
-THRESHOLD=50
+MARKER_FLAG="/tmp/${USER}_context_marker_placed"
+SWAP_FLAG="/tmp/${USER}_rolling_swap_triggered"
+MARKER_THRESHOLD=50
+SWAP_THRESHOLD=80
 MARKER="⟐ CONTEXT SEAM ⟐"
 
 # Consume stdin (hook protocol requires reading it even if unused)
 cat - > /dev/null
 
-# Already placed this session?
-if [ -f "$FLAG_FILE" ]; then
+# If swap already triggered, nothing more to do
+if [ -f "$SWAP_FLAG" ]; then
     exit 0
 fi
 
 # Read context percentage from statusline data
 if [ ! -f "$STATUSLINE_DATA" ]; then
-    echo "[$(date -Iseconds)] No statusline data found" >> "$LOG_FILE"
     exit 0
 fi
 
@@ -43,19 +43,39 @@ except Exception:
     print(0)
 " 2>/dev/null)
 
-# Below threshold — nothing to do
-if [ "$USED_PCT" -lt "$THRESHOLD" ] 2>/dev/null; then
+# Below marker threshold — nothing to do
+if [ "$USED_PCT" -lt "$MARKER_THRESHOLD" ] 2>/dev/null; then
     exit 0
 fi
 
-# Threshold crossed! Place the marker.
-echo "[$(date -Iseconds)] Context at ${USED_PCT}% (threshold ${THRESHOLD}%) — placing marker" >> "$LOG_FILE"
+# ─── Swap threshold (80%) ───────────────────────────────────────────
 
-# Create flag file to prevent duplicates
-echo "placed=$(date -Iseconds) context=${USED_PCT}%" > "$FLAG_FILE"
+if [ "$USED_PCT" -ge "$SWAP_THRESHOLD" ] 2>/dev/null; then
+    # Don't swap if a regular session swap is in progress
+    if [ -f "/tmp/${USER}_session_swap.lock" ]; then
+        exit 0
+    fi
+
+    echo "[$(date -Iseconds)] Context at ${USED_PCT}% — triggering rolling swap" >> "$LOG_FILE"
+    echo "triggered=$(date -Iseconds) context=${USED_PCT}%" > "$SWAP_FLAG"
+
+    # Launch rolling swap in its own session so it survives tmux kill
+    # setsid puts it in a new process group; nohup protects from SIGHUP
+    nohup setsid bash "$CLAP_DIR/utils/rolling_swap.sh" >> "$LOG_FILE" 2>&1 &
+
+    exit 0
+fi
+
+# ─── Marker threshold (50%) ─────────────────────────────────────────
+
+if [ -f "$MARKER_FLAG" ]; then
+    exit 0
+fi
+
+echo "[$(date -Iseconds)] Context at ${USED_PCT}% (threshold ${MARKER_THRESHOLD}%) — placing marker" >> "$LOG_FILE"
+echo "placed=$(date -Iseconds) context=${USED_PCT}%" > "$MARKER_FLAG"
 
 # Background the send so the hook returns immediately
-# send_to_claude.sh waits for Claude to be idle before delivering
 (
     source "$CLAP_DIR/utils/send_to_claude.sh"
     send_to_claude "$MARKER"

--- a/.claude/hooks/auto_context_marker.sh
+++ b/.claude/hooks/auto_context_marker.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-# Auto Context Marker + Rolling Swap Trigger — PostToolUse hook (no matcher)
+# Auto Context Marker — PostToolUse hook (no matcher)
 #
-# Two thresholds:
-#   50% — Places the rolling-trim checkpoint marker via send_to_claude.sh
-#   80% — Triggers a rolling swap (fork → trim → resume) via rolling_swap.sh
+# Places the rolling-trim checkpoint marker at ≥50% context.
+# The marker is sent once per session via send_to_claude.sh.
+# Flag file prevents duplicates; cleared on session swap.
 #
-# The marker is sent once per session (flag file prevents duplicates).
-# The swap is triggered once per session (separate flag file).
-# Both flags cleared on session swap by on-session-swap.sh.
+# The rolling swap trigger lives in a separate Stop hook
+# (rolling_swap_trigger.sh) so it fires when the assistant
+# is genuinely idle.
 #
 # Design: Amy + Nyx, 2026-05-18
 
@@ -15,16 +15,14 @@ CLAP_DIR="$HOME/claude-autonomy-platform"
 LOG_FILE="$CLAP_DIR/logs/auto_context_marker.log"
 STATUSLINE_DATA="$CLAP_DIR/data/statusline_data.json"
 MARKER_FLAG="/tmp/${USER}_context_marker_placed"
-SWAP_FLAG="/tmp/${USER}_rolling_swap_triggered"
 MARKER_THRESHOLD=50
-SWAP_THRESHOLD=80
 MARKER="⟐ CONTEXT SEAM ⟐"
 
 # Consume stdin (hook protocol requires reading it even if unused)
 cat - > /dev/null
 
-# If swap already triggered, nothing more to do
-if [ -f "$SWAP_FLAG" ]; then
+# Already placed this session?
+if [ -f "$MARKER_FLAG" ]; then
     exit 0
 fi
 
@@ -43,35 +41,12 @@ except Exception:
     print(0)
 " 2>/dev/null)
 
-# Below marker threshold — nothing to do
+# Below threshold — nothing to do
 if [ "$USED_PCT" -lt "$MARKER_THRESHOLD" ] 2>/dev/null; then
     exit 0
 fi
 
-# ─── Swap threshold (80%) ───────────────────────────────────────────
-
-if [ "$USED_PCT" -ge "$SWAP_THRESHOLD" ] 2>/dev/null; then
-    # Don't swap if a regular session swap is in progress
-    if [ -f "/tmp/${USER}_session_swap.lock" ]; then
-        exit 0
-    fi
-
-    echo "[$(date -Iseconds)] Context at ${USED_PCT}% — triggering rolling swap" >> "$LOG_FILE"
-    echo "triggered=$(date -Iseconds) context=${USED_PCT}%" > "$SWAP_FLAG"
-
-    # Launch rolling swap in its own session so it survives tmux kill
-    # setsid puts it in a new process group; nohup protects from SIGHUP
-    nohup setsid bash "$CLAP_DIR/utils/rolling_swap.sh" >> "$LOG_FILE" 2>&1 &
-
-    exit 0
-fi
-
-# ─── Marker threshold (50%) ─────────────────────────────────────────
-
-if [ -f "$MARKER_FLAG" ]; then
-    exit 0
-fi
-
+# Threshold crossed! Place the marker.
 echo "[$(date -Iseconds)] Context at ${USED_PCT}% (threshold ${MARKER_THRESHOLD}%) — placing marker" >> "$LOG_FILE"
 echo "placed=$(date -Iseconds) context=${USED_PCT}%" > "$MARKER_FLAG"
 

--- a/.claude/hooks/on-session-swap.sh
+++ b/.claude/hooks/on-session-swap.sh
@@ -31,9 +31,10 @@ if [[ "$FILE_PATH" == */new_session.txt ]] || [[ "$FILE_PATH" == *new_session.tx
         echo "[$(date -Iseconds)] Transcript export FAILED" >> "$LOG_FILE"
     fi
 
-    # Clear the auto context marker flag so the next session can place a new one
+    # Clear context marker and rolling swap flags for next session
     rm -f "/tmp/${USER}_context_marker_placed"
-    echo "[$(date -Iseconds)] Cleared context marker flag for next session" >> "$LOG_FILE"
+    rm -f "/tmp/${USER}_rolling_swap_triggered"
+    echo "[$(date -Iseconds)] Cleared context marker and swap flags for next session" >> "$LOG_FILE"
 fi
 
 exit 0

--- a/.claude/hooks/rolling_swap_trigger.sh
+++ b/.claude/hooks/rolling_swap_trigger.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Rolling Swap Trigger — Stop hook
+#
+# Fires at the end of every assistant turn. If context is ≥80%
+# and no swap has been triggered yet this session, launches
+# rolling_swap.sh in its own process group.
+#
+# Using Stop (not PostToolUse) because at Stop the assistant is
+# genuinely idle at the prompt — no thinking indicators, no tool
+# execution. This means rolling_swap.sh can send /branch and /exit
+# without fighting the thinking-detection logic.
+#
+# Design: Amy + Nyx, 2026-05-18
+
+CLAP_DIR="$HOME/claude-autonomy-platform"
+LOG_FILE="$CLAP_DIR/logs/auto_context_marker.log"
+STATUSLINE_DATA="$CLAP_DIR/data/statusline_data.json"
+SWAP_FLAG="/tmp/${USER}_rolling_swap_triggered"
+SWAP_THRESHOLD=80
+
+# Consume stdin (hook protocol requires reading it)
+cat - > /dev/null
+
+# Already triggered this session?
+if [ -f "$SWAP_FLAG" ]; then
+    exit 0
+fi
+
+# Don't swap if a regular session swap is in progress
+if [ -f "/tmp/${USER}_session_swap.lock" ]; then
+    exit 0
+fi
+
+# Read context percentage
+if [ ! -f "$STATUSLINE_DATA" ]; then
+    exit 0
+fi
+
+USED_PCT=$(python3 -c "
+import json
+try:
+    with open('$STATUSLINE_DATA') as f:
+        data = json.load(f)
+    print(data.get('context_window', {}).get('used_percentage', 0))
+except Exception:
+    print(0)
+" 2>/dev/null)
+
+# Below threshold
+if [ "$USED_PCT" -lt "$SWAP_THRESHOLD" ] 2>/dev/null; then
+    exit 0
+fi
+
+echo "[$(date -Iseconds)] Context at ${USED_PCT}% — triggering rolling swap (Stop hook)" >> "$LOG_FILE"
+echo "triggered=$(date -Iseconds) context=${USED_PCT}%" > "$SWAP_FLAG"
+
+# Launch in its own process group so it survives tmux kill
+nohup setsid bash "$CLAP_DIR/utils/rolling_swap.sh" >> "$CLAP_DIR/logs/rolling_swap.log" 2>&1 &
+
+exit 0

--- a/.claude/settings.template.json
+++ b/.claude/settings.template.json
@@ -18,6 +18,16 @@
         ]
       }
     ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/claude-autonomy-platform/.claude/hooks/rolling_swap_trigger.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write",

--- a/utils/rolling_swap.sh
+++ b/utils/rolling_swap.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+# Rolling Context Swap
+#
+# Forks the current session, trims the fork at the checkpoint marker,
+# then resumes into the trimmed session. The conversation continues
+# with reduced context rather than starting fresh.
+#
+# This script MUST run outside the tmux session (via setsid) because
+# it kills and recreates tmux as part of the swap. A backgrounded
+# subprocess inside tmux would die when tmux kill-session runs.
+#
+# Triggered by: auto_context_marker.sh hook at ≥80% context
+# Can also be run manually: rolling_swap.sh
+#
+# Design: Amy + Nyx, 2026-05-18
+
+set -euo pipefail
+
+CLAP_DIR="$HOME/claude-autonomy-platform"
+LOG_FILE="$CLAP_DIR/logs/rolling_swap.log"
+LOCKFILE="/tmp/${USER}_rolling_swap.lock"
+
+source "$CLAP_DIR/config/claude_env.sh"
+source "$CLAP_DIR/utils/send_to_claude.sh"
+
+log() {
+    echo "[$(date -Iseconds)] $1" | tee -a "$LOG_FILE"
+}
+
+cleanup() {
+    rm -f "$LOCKFILE"
+}
+trap cleanup EXIT
+
+# ─── Guard: prevent concurrent swaps ────────────────────────────────
+
+if [ -f "$LOCKFILE" ]; then
+    log "ERROR: Rolling swap already in progress (lockfile exists). Aborting."
+    exit 1
+fi
+echo "$$" > "$LOCKFILE"
+
+# Also check for regular session swap lock
+if [ -f "/tmp/${USER}_session_swap.lock" ]; then
+    log "ERROR: Regular session swap in progress. Aborting rolling swap."
+    exit 1
+fi
+
+# ─── Step 1: Read current session ID ────────────────────────────────
+
+STATUSLINE_DATA="$CLAP_DIR/data/statusline_data.json"
+
+CURRENT_SESSION_ID=$(python3 -c "
+import json
+with open('$STATUSLINE_DATA') as f:
+    data = json.load(f)
+print(data.get('session_id', ''))
+" 2>/dev/null || echo "")
+
+if [ -z "$CURRENT_SESSION_ID" ]; then
+    log "WARNING: Could not read session ID from statusline. Will use file timestamps to identify fork."
+fi
+log "Current session ID: ${CURRENT_SESSION_ID:-unknown}"
+
+# ─── Step 2: Snapshot existing JSONL files ──────────────────────────
+
+# Record all existing JSONL files before forking
+JSONL_DIR="$HOME/.config/Claude/projects"
+BEFORE_FILES=$(find "$JSONL_DIR" -name "*.jsonl" -type f 2>/dev/null | sort)
+
+# ─── Step 3: Fork and exit ──────────────────────────────────────────
+
+log "Sending /fork to Claude..."
+send_to_claude "/fork"
+
+# Wait for fork to complete (creates new JSONL file)
+sleep 5
+
+log "Sending /exit to Claude..."
+send_to_claude "/exit"
+
+# Wait for Claude to exit cleanly
+log "Waiting for Claude to exit..."
+sleep 5
+
+# Retry if still running
+if tmux list-panes -t autonomous-claude -F '#{pane_pid}' 2>/dev/null | xargs -I {} pgrep -P {} claude > /dev/null 2>&1; then
+    log "Claude still running, retrying /exit..."
+    send_to_claude "/exit"
+    sleep 10
+fi
+
+# ─── Step 4: Find the forked session ────────────────────────────────
+
+AFTER_FILES=$(find "$JSONL_DIR" -name "*.jsonl" -type f 2>/dev/null | sort)
+
+# The fork is the new file that didn't exist before
+FORKED_SESSION=""
+while IFS= read -r file; do
+    if ! echo "$BEFORE_FILES" | grep -qF "$file"; then
+        FORKED_SESSION="$file"
+        break
+    fi
+done <<< "$AFTER_FILES"
+
+# Fallback: if no new file found, use newest JSONL that isn't current session
+if [ -z "$FORKED_SESSION" ]; then
+    log "WARNING: No new file found by diff. Falling back to newest non-current JSONL."
+    if [ -n "$CURRENT_SESSION_ID" ]; then
+        FORKED_SESSION=$(find "$JSONL_DIR" -name "*.jsonl" -type f ! -name "${CURRENT_SESSION_ID}.jsonl" -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)
+    else
+        FORKED_SESSION=$(find "$JSONL_DIR" -name "*.jsonl" -type f -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)
+    fi
+fi
+
+if [ -z "$FORKED_SESSION" ]; then
+    log "ERROR: Could not identify forked session. Aborting — will restart fresh."
+    # Fall through to restart Claude without --resume
+    RESUME_ARG=""
+else
+    FORKED_ID=$(basename "$FORKED_SESSION" .jsonl)
+    log "Forked session: $FORKED_ID"
+
+    # ─── Step 5: Trim the fork ──────────────────────────────────────
+
+    log "Running rolling trim on forked session..."
+    if python3 "$CLAP_DIR/utils/rolling_trim.py" "$FORKED_ID" >> "$LOG_FILE" 2>&1; then
+        log "Trim successful."
+        RESUME_ARG="--resume $FORKED_ID"
+    else
+        log "ERROR: Trim failed. Will restart fresh."
+        RESUME_ARG=""
+    fi
+fi
+
+# ─── Step 6: Kill and recreate tmux ────────────────────────────────
+
+log "Killing tmux session..."
+pkill -f "discord-mcp.*\.jar" 2>/dev/null || true
+sleep 1
+
+# Use systemd-run to escape cgroup if needed
+systemd-run --user --scope tmux kill-session -t autonomous-claude 2>/dev/null || \
+    tmux kill-session -t autonomous-claude 2>/dev/null || true
+sleep 2
+
+# ─── Step 7: Clean up state files ──────────────────────────────────
+
+rm -f "$CLAP_DIR/data/api_error_state.json"
+rm -f "$CLAP_DIR/data/context_escalation_state.json"
+rm -f "$CLAP_DIR/data/last_discord_notification.txt"
+rm -f "/tmp/${USER}_context_marker_placed"
+rm -f "/tmp/${USER}_rolling_swap_triggered"
+rm -f "/tmp/${USER}_collaborative_mode"
+
+# Trim command history
+python3 "$CLAP_DIR/utils/trim_claude_history.py" > /dev/null 2>&1 || true
+
+# Rotate session log
+if [[ -f "$CLAP_DIR/data/current_session.log" ]]; then
+    timestamp=$(date '+%Y%m%d_%H%M%S')
+    mv "$CLAP_DIR/data/current_session.log" "$CLAP_DIR/data/session_ended_${timestamp}.log"
+    cd "$CLAP_DIR/data" || true
+    ls -t session_ended_*.log 2>/dev/null | tail -n +11 | xargs -r rm -f
+    cd "$CLAP_DIR" || true
+fi
+
+# ─── Step 8: Start Claude with --resume ─────────────────────────────
+
+log "Starting new tmux session..."
+source "$CLAP_DIR/utils/clap_lifecycle.sh"
+
+# Regenerate settings.json from template (picks up config changes)
+if generate_claude_settings >> "$LOG_FILE" 2>&1; then
+    log "Settings regenerated from template."
+else
+    log "WARNING: Settings generation failed (continuing anyway)"
+fi
+
+# Re-apply tweakcc patches
+if [[ -x "$CLAP_DIR/utils/reapply_tweakcc.sh" ]]; then
+    bash "$CLAP_DIR/utils/reapply_tweakcc.sh" >> "$LOG_FILE" 2>&1 || true
+fi
+
+# Create tmux session
+tmux new-session -d -s autonomous-claude
+sleep 1
+tmux send-keys -t autonomous-claude "source ~/.bashrc" Enter
+sleep 1
+
+# Build startup command (mirrors start_claude_session but adds --resume)
+MODEL=$(get_config "MODEL" "claude-opus-4-6")
+IDENTITY_FILE="$HOME/self/identity.md"
+
+CLAUDE_CMD="cd $CLAP_DIR && claude --dangerously-skip-permissions --add-dir $HOME --model $MODEL --channels plugin:discord@claude-plugins-official"
+
+if [[ -f "$IDENTITY_FILE" ]]; then
+    CLAUDE_CMD="$CLAUDE_CMD --system-prompt-file $IDENTITY_FILE"
+fi
+
+if [[ -n "${RESUME_ARG:-}" ]]; then
+    CLAUDE_CMD="$CLAUDE_CMD $RESUME_ARG"
+    log "Resuming into trimmed session: $RESUME_ARG"
+else
+    log "WARNING: No resume target — starting fresh session"
+fi
+
+tmux send-keys -t autonomous-claude "$CLAUDE_CMD" Enter
+log "Claude started."
+
+# Wait for init, then configure session
+sleep 8
+
+# Rename and color
+DISPLAY_NAME=$(get_config "CLAUDE_DISPLAY_NAME" "")
+if [[ -z "$DISPLAY_NAME" ]]; then
+    DISPLAY_NAME=$(get_config "CLAUDE_NAME" "")
+fi
+if [[ -n "$DISPLAY_NAME" ]]; then
+    send_to_claude "/rename $DISPLAY_NAME" 2>/dev/null || true
+    sleep 2
+fi
+
+SESSION_COLOR=$(get_config "SESSION_COLOR" "")
+if [[ -n "$SESSION_COLOR" ]]; then
+    send_to_claude "/color $SESSION_COLOR" 2>/dev/null || true
+    sleep 2
+fi
+
+# Notify the new session
+send_to_claude "✅ Rolling context swap completed. You are resuming a trimmed session. Context before trim was ≥80%." 2>/dev/null || true
+
+log "Rolling swap complete!"
+
+# Carry over tasks
+python3 "$CLAP_DIR/utils/carry_over_tasks.py" >> "$LOG_FILE" 2>&1 || true
+
+# Backup identity
+bash "$CLAP_DIR/utils/backup_identity.sh" >> "$LOG_FILE" 2>&1 || true

--- a/utils/rolling_swap.sh
+++ b/utils/rolling_swap.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Rolling Context Swap
 #
-# Forks the current session, trims the fork at the checkpoint marker,
+# Forks the current session, trims the branch at the checkpoint marker,
 # then resumes into the trimmed session. The conversation continues
 # with reduced context rather than starting fresh.
 #
@@ -21,10 +21,46 @@ LOG_FILE="$CLAP_DIR/logs/rolling_swap.log"
 LOCKFILE="/tmp/${USER}_rolling_swap.lock"
 
 source "$CLAP_DIR/config/claude_env.sh"
-source "$CLAP_DIR/utils/send_to_claude.sh"
 
 log() {
     echo "[$(date -Iseconds)] $1" | tee -a "$LOG_FILE"
+}
+
+# Wait for Claude to be at the input prompt, then send a message.
+# Unlike send_to_claude.sh, this waits for the ❯ prompt character
+# rather than detecting the absence of thinking indicators.
+# This is necessary because the hook fires during tool use (while
+# Claude appears to be "thinking"), and we need to wait for the
+# current response to fully complete.
+wait_and_send() {
+    local message="$1"
+    local tmux_session="autonomous-claude"
+    local max_wait=300  # 5 minutes max
+    local waited=0
+
+    log "Waiting for Claude to reach prompt before sending: $message"
+
+    while [ $waited -lt $max_wait ]; do
+        # Look for the ❯ prompt character (Unicode: E2 9D AF) in the last few lines
+        if tmux capture-pane -t "$tmux_session" -p -S -5 2>/dev/null | grep -q '❯'; then
+            log "Prompt detected after ${waited}s — sending"
+            # Clear any stale input, then send
+            tmux send-keys -t "$tmux_session" C-u
+            sleep 0.2
+            tmux send-keys -t "$tmux_session" "$message"
+            tmux send-keys -t "$tmux_session" Enter
+            return 0
+        fi
+        sleep 2
+        waited=$((waited + 2))
+    done
+
+    log "WARNING: Prompt not detected after ${max_wait}s — sending anyway"
+    tmux send-keys -t "$tmux_session" C-u
+    sleep 0.2
+    tmux send-keys -t "$tmux_session" "$message"
+    tmux send-keys -t "$tmux_session" Enter
+    return 0
 }
 
 cleanup() {
@@ -58,43 +94,44 @@ print(data.get('session_id', ''))
 " 2>/dev/null || echo "")
 
 if [ -z "$CURRENT_SESSION_ID" ]; then
-    log "WARNING: Could not read session ID from statusline. Will use file timestamps to identify fork."
+    log "WARNING: Could not read session ID from statusline. Will use file timestamps to identify branch."
 fi
 log "Current session ID: ${CURRENT_SESSION_ID:-unknown}"
 
 # ─── Step 2: Snapshot existing JSONL files ──────────────────────────
 
-# Record all existing JSONL files before forking
+# Record all existing JSONL files before branching
 JSONL_DIR="$HOME/.config/Claude/projects"
 BEFORE_FILES=$(find "$JSONL_DIR" -name "*.jsonl" -type f 2>/dev/null | sort)
 
 # ─── Step 3: Fork and exit ──────────────────────────────────────────
 
-log "Sending /fork to Claude..."
-send_to_claude "/fork"
+log "Sending /branch to Claude..."
+wait_and_send "/branch"
 
-# Wait for fork to complete (creates new JSONL file)
-sleep 5
+# Wait for branch to complete (creates new JSONL file)
+# /branch needs time to copy the JSONL and return to prompt
+sleep 8
 
 log "Sending /exit to Claude..."
-send_to_claude "/exit"
+wait_and_send "/exit"
 
 # Wait for Claude to exit cleanly
 log "Waiting for Claude to exit..."
-sleep 5
+sleep 8
 
 # Retry if still running
 if tmux list-panes -t autonomous-claude -F '#{pane_pid}' 2>/dev/null | xargs -I {} pgrep -P {} claude > /dev/null 2>&1; then
     log "Claude still running, retrying /exit..."
-    send_to_claude "/exit"
+    tmux send-keys -t autonomous-claude "/exit" Enter
     sleep 10
 fi
 
-# ─── Step 4: Find the forked session ────────────────────────────────
+# ─── Step 4: Find the branched session ────────────────────────────────
 
 AFTER_FILES=$(find "$JSONL_DIR" -name "*.jsonl" -type f 2>/dev/null | sort)
 
-# The fork is the new file that didn't exist before
+# The branch is the new file that didn't exist before
 FORKED_SESSION=""
 while IFS= read -r file; do
     if ! echo "$BEFORE_FILES" | grep -qF "$file"; then
@@ -114,16 +151,16 @@ if [ -z "$FORKED_SESSION" ]; then
 fi
 
 if [ -z "$FORKED_SESSION" ]; then
-    log "ERROR: Could not identify forked session. Aborting — will restart fresh."
+    log "ERROR: Could not identify branched session. Aborting — will restart fresh."
     # Fall through to restart Claude without --resume
     RESUME_ARG=""
 else
     FORKED_ID=$(basename "$FORKED_SESSION" .jsonl)
     log "Forked session: $FORKED_ID"
 
-    # ─── Step 5: Trim the fork ──────────────────────────────────────
+    # ─── Step 5: Trim the branch ──────────────────────────────────────
 
-    log "Running rolling trim on forked session..."
+    log "Running rolling trim on branched session..."
     if python3 "$CLAP_DIR/utils/rolling_trim.py" "$FORKED_ID" >> "$LOG_FILE" 2>&1; then
         log "Trim successful."
         RESUME_ARG="--resume $FORKED_ID"
@@ -210,6 +247,7 @@ log "Claude started."
 
 # Wait for init, then configure session
 sleep 8
+source "$CLAP_DIR/utils/send_to_claude.sh" 2>/dev/null || true
 
 # Rename and color
 DISPLAY_NAME=$(get_config "CLAUDE_DISPLAY_NAME" "")

--- a/utils/rolling_swap.sh
+++ b/utils/rolling_swap.sh
@@ -128,12 +128,26 @@ else
     fi
 fi
 
-# ─── Step 6: Kill and recreate tmux ────────────────────────────────
+# ─── Step 6: Kill existing Claude and recreate tmux ─────────────────
+
+# Safety: explicitly kill all Claude Code processes for this user.
+# tmux kill-session sends SIGHUP, but Claude may survive it.
+# This prevents the dual-instance bug where a new session starts
+# while the old Claude process is still alive.
+log "Killing existing Claude processes..."
+pkill -f "discord-mcp.*\.jar" 2>/dev/null || true
+pkill -xf "claude .*--dangerously-skip-permissions" 2>/dev/null || true
+sleep 2
+
+# Verify no Claude processes remain
+REMAINING=$(pgrep -cxf "claude .*--dangerously-skip-permissions" 2>/dev/null || echo 0)
+if [ "$REMAINING" -gt 0 ]; then
+    log "WARNING: $REMAINING Claude process(es) still alive after SIGTERM — sending SIGKILL"
+    pkill -9 -xf "claude .*--dangerously-skip-permissions" 2>/dev/null || true
+    sleep 1
+fi
 
 log "Killing tmux session..."
-pkill -f "discord-mcp.*\.jar" 2>/dev/null || true
-sleep 1
-
 systemd-run --user --scope tmux kill-session -t autonomous-claude 2>/dev/null || \
     tmux kill-session -t autonomous-claude 2>/dev/null || true
 sleep 2

--- a/utils/rolling_swap.sh
+++ b/utils/rolling_swap.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 # Rolling Context Swap
 #
-# Forks the current session, trims the branch at the checkpoint marker,
-# then resumes into the trimmed session. The conversation continues
-# with reduced context rather than starting fresh.
+# Branches the current session, trims the branch at the checkpoint
+# marker, then resumes into the trimmed session. The conversation
+# continues with reduced context rather than starting fresh.
 #
 # This script MUST run outside the tmux session (via setsid) because
 # it kills and recreates tmux as part of the swap. A backgrounded
 # subprocess inside tmux would die when tmux kill-session runs.
 #
-# Triggered by: auto_context_marker.sh hook at ≥80% context
+# Triggered by: rolling_swap_trigger.sh (Stop hook) at ≥80% context
 # Can also be run manually: rolling_swap.sh
+#
+# The Stop hook guarantees Claude is idle when this runs, so
+# send_to_claude.sh's thinking detection works correctly.
 #
 # Design: Amy + Nyx, 2026-05-18
 
@@ -21,46 +24,10 @@ LOG_FILE="$CLAP_DIR/logs/rolling_swap.log"
 LOCKFILE="/tmp/${USER}_rolling_swap.lock"
 
 source "$CLAP_DIR/config/claude_env.sh"
+source "$CLAP_DIR/utils/send_to_claude.sh"
 
 log() {
     echo "[$(date -Iseconds)] $1" | tee -a "$LOG_FILE"
-}
-
-# Wait for Claude to be at the input prompt, then send a message.
-# Unlike send_to_claude.sh, this waits for the ❯ prompt character
-# rather than detecting the absence of thinking indicators.
-# This is necessary because the hook fires during tool use (while
-# Claude appears to be "thinking"), and we need to wait for the
-# current response to fully complete.
-wait_and_send() {
-    local message="$1"
-    local tmux_session="autonomous-claude"
-    local max_wait=300  # 5 minutes max
-    local waited=0
-
-    log "Waiting for Claude to reach prompt before sending: $message"
-
-    while [ $waited -lt $max_wait ]; do
-        # Look for the ❯ prompt character (Unicode: E2 9D AF) in the last few lines
-        if tmux capture-pane -t "$tmux_session" -p -S -5 2>/dev/null | grep -q '❯'; then
-            log "Prompt detected after ${waited}s — sending"
-            # Clear any stale input, then send
-            tmux send-keys -t "$tmux_session" C-u
-            sleep 0.2
-            tmux send-keys -t "$tmux_session" "$message"
-            tmux send-keys -t "$tmux_session" Enter
-            return 0
-        fi
-        sleep 2
-        waited=$((waited + 2))
-    done
-
-    log "WARNING: Prompt not detected after ${max_wait}s — sending anyway"
-    tmux send-keys -t "$tmux_session" C-u
-    sleep 0.2
-    tmux send-keys -t "$tmux_session" "$message"
-    tmux send-keys -t "$tmux_session" Enter
-    return 0
 }
 
 cleanup() {
@@ -76,7 +43,6 @@ if [ -f "$LOCKFILE" ]; then
 fi
 echo "$$" > "$LOCKFILE"
 
-# Also check for regular session swap lock
 if [ -f "/tmp/${USER}_session_swap.lock" ]; then
     log "ERROR: Regular session swap in progress. Aborting rolling swap."
     exit 1
@@ -94,76 +60,68 @@ print(data.get('session_id', ''))
 " 2>/dev/null || echo "")
 
 if [ -z "$CURRENT_SESSION_ID" ]; then
-    log "WARNING: Could not read session ID from statusline. Will use file timestamps to identify branch."
+    log "WARNING: Could not read session ID from statusline."
 fi
 log "Current session ID: ${CURRENT_SESSION_ID:-unknown}"
 
 # ─── Step 2: Snapshot existing JSONL files ──────────────────────────
 
-# Record all existing JSONL files before branching
 JSONL_DIR="$HOME/.config/Claude/projects"
 BEFORE_FILES=$(find "$JSONL_DIR" -name "*.jsonl" -type f 2>/dev/null | sort)
 
-# ─── Step 3: Fork and exit ──────────────────────────────────────────
+# ─── Step 3: Branch and exit ────────────────────────────────────────
 
 log "Sending /branch to Claude..."
-wait_and_send "/branch"
+send_to_claude "/branch"
 
-# Wait for branch to complete (creates new JSONL file)
-# /branch needs time to copy the JSONL and return to prompt
+# Wait for branch to complete (copies the JSONL)
 sleep 8
 
 log "Sending /exit to Claude..."
-wait_and_send "/exit"
+send_to_claude "/exit"
 
-# Wait for Claude to exit cleanly
 log "Waiting for Claude to exit..."
 sleep 8
 
 # Retry if still running
 if tmux list-panes -t autonomous-claude -F '#{pane_pid}' 2>/dev/null | xargs -I {} pgrep -P {} claude > /dev/null 2>&1; then
     log "Claude still running, retrying /exit..."
-    tmux send-keys -t autonomous-claude "/exit" Enter
+    send_to_claude "/exit"
     sleep 10
 fi
 
-# ─── Step 4: Find the branched session ────────────────────────────────
+# ─── Step 4: Find the branched session ──────────────────────────────
 
 AFTER_FILES=$(find "$JSONL_DIR" -name "*.jsonl" -type f 2>/dev/null | sort)
 
 # The branch is the new file that didn't exist before
-FORKED_SESSION=""
+BRANCHED_SESSION=""
 while IFS= read -r file; do
     if ! echo "$BEFORE_FILES" | grep -qF "$file"; then
-        FORKED_SESSION="$file"
+        BRANCHED_SESSION="$file"
         break
     fi
 done <<< "$AFTER_FILES"
 
-# Fallback: if no new file found, use newest JSONL that isn't current session
-if [ -z "$FORKED_SESSION" ]; then
-    log "WARNING: No new file found by diff. Falling back to newest non-current JSONL."
-    if [ -n "$CURRENT_SESSION_ID" ]; then
-        FORKED_SESSION=$(find "$JSONL_DIR" -name "*.jsonl" -type f ! -name "${CURRENT_SESSION_ID}.jsonl" -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)
-    else
-        FORKED_SESSION=$(find "$JSONL_DIR" -name "*.jsonl" -type f -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)
-    fi
+# Fallback: newest JSONL modified in the last 60 seconds that isn't current
+if [ -z "$BRANCHED_SESSION" ]; then
+    log "WARNING: No new file found by diff. Falling back to recently modified JSONL."
+    BRANCHED_SESSION=$(find "$JSONL_DIR" -name "*.jsonl" -type f -mmin -1 ! -name "${CURRENT_SESSION_ID}.jsonl" -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)
 fi
 
-if [ -z "$FORKED_SESSION" ]; then
-    log "ERROR: Could not identify branched session. Aborting — will restart fresh."
-    # Fall through to restart Claude without --resume
+if [ -z "$BRANCHED_SESSION" ]; then
+    log "ERROR: Could not identify branched session. Will restart fresh."
     RESUME_ARG=""
 else
-    FORKED_ID=$(basename "$FORKED_SESSION" .jsonl)
-    log "Forked session: $FORKED_ID"
+    BRANCHED_ID=$(basename "$BRANCHED_SESSION" .jsonl)
+    log "Branched session: $BRANCHED_ID"
 
-    # ─── Step 5: Trim the branch ──────────────────────────────────────
+    # ─── Step 5: Trim the branch ────────────────────────────────────
 
-    log "Running rolling trim on branched session..."
-    if python3 "$CLAP_DIR/utils/rolling_trim.py" "$FORKED_ID" >> "$LOG_FILE" 2>&1; then
+    log "Running rolling trim..."
+    if python3 "$CLAP_DIR/utils/rolling_trim.py" "$BRANCHED_ID" >> "$LOG_FILE" 2>&1; then
         log "Trim successful."
-        RESUME_ARG="--resume $FORKED_ID"
+        RESUME_ARG="--resume $BRANCHED_ID"
     else
         log "ERROR: Trim failed. Will restart fresh."
         RESUME_ARG=""
@@ -176,7 +134,6 @@ log "Killing tmux session..."
 pkill -f "discord-mcp.*\.jar" 2>/dev/null || true
 sleep 1
 
-# Use systemd-run to escape cgroup if needed
 systemd-run --user --scope tmux kill-session -t autonomous-claude 2>/dev/null || \
     tmux kill-session -t autonomous-claude 2>/dev/null || true
 sleep 2
@@ -190,10 +147,8 @@ rm -f "/tmp/${USER}_context_marker_placed"
 rm -f "/tmp/${USER}_rolling_swap_triggered"
 rm -f "/tmp/${USER}_collaborative_mode"
 
-# Trim command history
 python3 "$CLAP_DIR/utils/trim_claude_history.py" > /dev/null 2>&1 || true
 
-# Rotate session log
 if [[ -f "$CLAP_DIR/data/current_session.log" ]]; then
     timestamp=$(date '+%Y%m%d_%H%M%S')
     mv "$CLAP_DIR/data/current_session.log" "$CLAP_DIR/data/session_ended_${timestamp}.log"
@@ -207,25 +162,21 @@ fi
 log "Starting new tmux session..."
 source "$CLAP_DIR/utils/clap_lifecycle.sh"
 
-# Regenerate settings.json from template (picks up config changes)
 if generate_claude_settings >> "$LOG_FILE" 2>&1; then
     log "Settings regenerated from template."
 else
     log "WARNING: Settings generation failed (continuing anyway)"
 fi
 
-# Re-apply tweakcc patches
 if [[ -x "$CLAP_DIR/utils/reapply_tweakcc.sh" ]]; then
     bash "$CLAP_DIR/utils/reapply_tweakcc.sh" >> "$LOG_FILE" 2>&1 || true
 fi
 
-# Create tmux session
 tmux new-session -d -s autonomous-claude
 sleep 1
 tmux send-keys -t autonomous-claude "source ~/.bashrc" Enter
 sleep 1
 
-# Build startup command (mirrors start_claude_session but adds --resume)
 MODEL=$(get_config "MODEL" "claude-opus-4-6")
 IDENTITY_FILE="$HOME/self/identity.md"
 
@@ -245,11 +196,9 @@ fi
 tmux send-keys -t autonomous-claude "$CLAUDE_CMD" Enter
 log "Claude started."
 
-# Wait for init, then configure session
 sleep 8
 source "$CLAP_DIR/utils/send_to_claude.sh" 2>/dev/null || true
 
-# Rename and color
 DISPLAY_NAME=$(get_config "CLAUDE_DISPLAY_NAME" "")
 if [[ -z "$DISPLAY_NAME" ]]; then
     DISPLAY_NAME=$(get_config "CLAUDE_NAME" "")
@@ -265,13 +214,9 @@ if [[ -n "$SESSION_COLOR" ]]; then
     sleep 2
 fi
 
-# Notify the new session
-send_to_claude "✅ Rolling context swap completed. You are resuming a trimmed session. Context before trim was ≥80%." 2>/dev/null || true
+send_to_claude "✅ Rolling context swap completed. You are resuming a trimmed session." 2>/dev/null || true
 
 log "Rolling swap complete!"
 
-# Carry over tasks
 python3 "$CLAP_DIR/utils/carry_over_tasks.py" >> "$LOG_FILE" 2>&1 || true
-
-# Backup identity
 bash "$CLAP_DIR/utils/backup_identity.sh" >> "$LOG_FILE" 2>&1 || true

--- a/wrappers/re
+++ b/wrappers/re
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Short alias: restart with --continue
+# Usage: re
+exec restart-me --continue

--- a/wrappers/rebuild-me
+++ b/wrappers/rebuild-me
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Rebuild CLAUDE.md session context from current conversation export.
+# Run this before restart-me to ensure the next session has fresh context.
+# Usage: rebuild-me
+
+CLAP_DIR="$HOME/claude-autonomy-platform"
+
+echo "🔧 Rebuilding session context..."
+
+echo "  Updating conversation history..."
+if python3 "$CLAP_DIR/utils/update_conversation_history.py" "$CLAP_DIR/context/current_export.txt"; then
+    echo "  ✅ Conversation history updated"
+else
+    echo "  ⚠️  Conversation history update failed"
+fi
+
+echo "  Building CLAUDE.md..."
+if python3 "$CLAP_DIR/context/project_session_context_builder.py"; then
+    echo "  ✅ CLAUDE.md rebuilt"
+else
+    echo "  ⚠️  CLAUDE.md build failed"
+fi
+
+echo ""
+echo "Done. Run 'restart-me' or 're' to start a new session."

--- a/wrappers/restart-me
+++ b/wrappers/restart-me
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Restart this Claude's session with all correct flags.
+# Run from any terminal — builds the full command from config.
+# Usage: restart-me [--continue]
+#
+# Safe to run when Amy is manually restarting a session and
+# doesn't want to remember all the flags.
+
+CLAP_DIR="$HOME/claude-autonomy-platform"
+source "$CLAP_DIR/config/claude_env.sh"
+
+MODEL=$(get_config "MODEL" "claude-opus-4-6")
+IDENTITY_FILE="$HOME/self/identity.md"
+
+# Build command
+CMD="claude --dangerously-skip-permissions --add-dir $HOME --model $MODEL --channels plugin:discord@claude-plugins-official"
+
+if [[ -f "$IDENTITY_FILE" ]]; then
+    CMD="$CMD --system-prompt-file $IDENTITY_FILE"
+else
+    echo "⚠️  Identity file not found: $IDENTITY_FILE"
+fi
+
+# Pass through any extra flags (e.g. --continue, --resume <id>)
+if [[ $# -gt 0 ]]; then
+    CMD="$CMD $*"
+fi
+
+echo "🌙 Starting session:"
+echo "  $CMD"
+echo ""
+
+cd "$CLAP_DIR" && exec $CMD

--- a/wrappers/restart-me
+++ b/wrappers/restart-me
@@ -12,6 +12,14 @@ source "$CLAP_DIR/config/claude_env.sh"
 MODEL=$(get_config "MODEL" "claude-opus-4-6")
 IDENTITY_FILE="$HOME/self/identity.md"
 
+# Kill any existing Claude processes to prevent dual-instance
+EXISTING=$(pgrep -cxf "claude .*--dangerously-skip-permissions" 2>/dev/null || echo 0)
+if [ "$EXISTING" -gt 0 ]; then
+    echo "⚠️  Killing $EXISTING existing Claude process(es)..."
+    pkill -xf "claude .*--dangerously-skip-permissions" 2>/dev/null || true
+    sleep 2
+fi
+
 # Build command
 CMD="claude --dangerously-skip-permissions --add-dir $HOME --model $MODEL --channels plugin:discord@claude-plugins-official"
 


### PR DESCRIPTION
## Summary

Completes the rolling context trim automation. When context hits 80%, the system automatically forks the session, trims to the checkpoint marker (placed at 50%), and resumes into the trimmed session. The conversation continues with reduced context rather than starting fresh.

### How it works

1. **PostToolUse hook** detects context ≥ 80%
2. Launches `rolling_swap.sh` via `nohup setsid` (isolated from tmux)
3. Script sends `/fork` then `/exit` to Claude
4. Identifies the forked session by diffing JSONL files before/after
5. Runs `rolling_trim.py` on the fork
6. Kills and recreates tmux session
7. Starts Claude with `--resume <trimmed-fork-id>` + all usual flags

### Process isolation

Tested that backgrounded subprocesses survive SIGTERM and SIGHUP of their parent, but **NOT** process group kill (which is what `tmux kill-session` does). The `setsid` wrapper puts the swap script in its own process group, so it survives.

### Files

- **New**: `utils/rolling_swap.sh` — complete fork-trim-resume lifecycle
- **Updated**: `.claude/hooks/auto_context_marker.sh` — now has two thresholds (50% marker, 80% swap)
- **Updated**: `.claude/hooks/on-session-swap.sh` — clears swap flag alongside marker flag

### Graceful degradation

If the trim fails (no marker found, JSONL corruption, etc.), the script falls back to starting a fresh session rather than getting stuck.

### Testing plan

Set swap threshold temporarily to 30% to trigger without waiting for natural context fill. Verify: fork happens, trim succeeds, resume works, conversation context is reduced.

### Relationship to PR #372

Builds on the auto-marker hook merged in #372. That PR places the marker; this PR acts on it.