### PR TITLE
Build minimal CLAUDE.md for rolling swap resume

### DIFF
--- a/context/project_session_context_builder.py
+++ b/context/project_session_context_builder.py
@@ -76,8 +76,12 @@ def update_clap_architecture_tree(autonomy_dir):
     except Exception as e:
         print(f"Warning: Could not update directory tree - {e}")
 
-def build_claude_md():
-    """Build CLAUDE.md from architecture and conversation history"""
+def build_claude_md(minimal=False):
+    """Build CLAUDE.md from architecture and conversation history.
+
+    If minimal=True (used by rolling swap), skips conversation history
+    and context hats — the trimmed session JSONL carries those forward.
+    """
     
     # Define paths
     autonomy_dir = Path(__file__).parent
@@ -143,43 +147,41 @@ def build_claude_md():
             except Exception as e:
                 print(f"Warning: Could not read Discord channels - {e}")
         
-        # Read swap content
-        with open(swap_file, 'r', encoding='utf-8') as f:
-            swap_content = f.read()
-        
-        # Check for context hat keyword and load appropriate context
+        # Read swap content and context hats (skip for rolling swap)
+        swap_content = ""
         context_hat_content = ""
-        if new_session_file.exists():
-            with open(new_session_file, 'r', encoding='utf-8') as f:
-                keyword = f.read().strip().upper()
-            
-            # Load context hats configuration
-            config_file = autonomy_dir / "context_hats_config.json"
-            context_docs = {}
-            
-            if config_file.exists():
-                try:
-                    with open(config_file, 'r', encoding='utf-8') as f:
-                        config = json.load(f)
-                        for key, value in config.get("context_hats", {}).items():
-                            if value.get("path"):
-                                # Resolve path relative to autonomy_dir
-                                context_docs[key] = autonomy_dir / value["path"]
-                            else:
-                                context_docs[key] = None
-                except (json.JSONDecodeError, KeyError) as e:
-                    print(f"Warning: Error loading context hats config - {e}")
-                    # Fallback to default AUTONOMY context
+
+        if not minimal:
+            with open(swap_file, 'r', encoding='utf-8') as f:
+                swap_content = f.read()
+
+            if new_session_file.exists():
+                with open(new_session_file, 'r', encoding='utf-8') as f:
+                    keyword = f.read().strip().upper()
+
+                config_file = autonomy_dir / "context_hats_config.json"
+                context_docs = {}
+
+                if config_file.exists():
+                    try:
+                        with open(config_file, 'r', encoding='utf-8') as f:
+                            config = json.load(f)
+                            for key, value in config.get("context_hats", {}).items():
+                                if value.get("path"):
+                                    context_docs[key] = autonomy_dir / value["path"]
+                                else:
+                                    context_docs[key] = None
+                    except (json.JSONDecodeError, KeyError) as e:
+                        print(f"Warning: Error loading context hats config - {e}")
+                        context_docs = {"AUTONOMY": autonomy_dir / "autonomy-status.md"}
+                else:
                     context_docs = {"AUTONOMY": autonomy_dir / "autonomy-status.md"}
-            else:
-                # Fallback to default AUTONOMY context if no config file
-                context_docs = {"AUTONOMY": autonomy_dir / "autonomy-status.md"}
-            
-            if keyword in context_docs and keyword != "NONE":
-                context_file = context_docs[keyword]
-                if context_file and context_file.exists():
-                    with open(context_file, 'r', encoding='utf-8') as f:
-                        context_hat_content = f"\n## Context Hat: {keyword}\n\n{f.read()}\n"
+
+                if keyword in context_docs and keyword != "NONE":
+                    context_file = context_docs[keyword]
+                    if context_file and context_file.exists():
+                        with open(context_file, 'r', encoding='utf-8') as f:
+                            context_hat_content = f"\n## Context Hat: {keyword}\n\n{f.read()}\n"
                 
         
         # Directory tree auto-update disabled - tree becomes stale quickly and clutters git diffs
@@ -188,25 +190,33 @@ def build_claude_md():
         # Handoff notifications removed - only one type of swap now
         
         # Combine content with clear separation
-        combined_content = f"""# Current Session Context
+        if minimal:
+            combined_content = f"""# Current Session Context
+*Updated: {datetime.now().timestamp()}*
+
+{architecture_content}{personal_interests_content}{natural_commands_content}{personal_commands_content}{discord_channels_content}"""
+        else:
+            combined_content = f"""# Current Session Context
 *Updated: {Path(swap_file).stat().st_mtime}*
 
 {architecture_content}{personal_interests_content}{natural_commands_content}{personal_commands_content}{discord_channels_content}{context_hat_content}
 ## Recent Conversation Context
 
 {swap_content}"""
-        
+
         # Write to CLAUDE.md
         with open(claude_md_file, 'w', encoding='utf-8') as f:
             f.write(combined_content)
-        
-        print(f"Successfully updated {claude_md_file}")
+
+        mode = "minimal (rolling swap)" if minimal else "full"
+        print(f"Successfully updated {claude_md_file} ({mode})")
         print(f"- Architecture from: {architecture_file}")
-        print(f"- Conversation from: {swap_file}")
-        if context_hat_content:
-            print(f"- Context hat: {keyword}")
-        else:
-            print(f"- No context hat content added (keyword was: {keyword if new_session_file.exists() else 'No keyword file'})")
+        if not minimal:
+            print(f"- Conversation from: {swap_file}")
+            if context_hat_content:
+                print(f"- Context hat: {keyword}")
+            else:
+                print(f"- No context hat content added (keyword was: {keyword if new_session_file.exists() else 'No keyword file'})")
         
     except FileNotFoundError as e:
         print(f"Error: Required file not found - {e}")
@@ -218,5 +228,6 @@ def build_claude_md():
     return True
 
 if __name__ == "__main__":
-    success = build_claude_md()
+    minimal = "--minimal" in sys.argv
+    success = build_claude_md(minimal=minimal)
     exit(0 if success else 1)

--- a/utils/rolling_swap.sh
+++ b/utils/rolling_swap.sh
@@ -186,6 +186,14 @@ if [[ -x "$CLAP_DIR/utils/reapply_tweakcc.sh" ]]; then
     bash "$CLAP_DIR/utils/reapply_tweakcc.sh" >> "$LOG_FILE" 2>&1 || true
 fi
 
+# Build minimal CLAUDE.md (architecture + commands only, no conversation history)
+# The trimmed session JSONL carries conversation forward
+if python3 "$CLAP_DIR/context/project_session_context_builder.py" --minimal >> "$LOG_FILE" 2>&1; then
+    log "CLAUDE.md rebuilt (minimal — conversation in JSONL)."
+else
+    log "WARNING: Minimal CLAUDE.md build failed (continuing anyway)"
+fi
+
 tmux new-session -d -s autonomous-claude
 sleep 1
 tmux send-keys -t autonomous-claude "source ~/.bashrc" Enter


### PR DESCRIPTION
## Summary

When rolling swap resumes a trimmed session, the conversation is already in the JSONL — duplicating it in CLAUDE.md wastes context tokens.

Adds `--minimal` flag to `project_session_context_builder.py`:
- **Includes**: architecture, personal interests, commands, channels
- **Skips**: conversation history (swap_CLAUDE.md), context hats

`rolling_swap.sh` now calls `--minimal` before starting the resumed session.

Follows from Amy's observation that the resumed session's CLAUDE.md should be lean since the trim carries conversation forward.