### PR TITLE
Add Garden MCP server to shared config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,15 @@
       "env": {
         "DB_FILE_PATH": "${PERSONAL_DIR}/rag-memory.db"
       }
+    },
+    "garden": {
+      "type": "stdio",
+      "command": "python3",
+      "args": ["/mnt/file_server/Shared/garden/mcp_server.py"],
+      "env": {
+        "GARDEN_VISITOR": "${CLAUDE_NAME}",
+        "GARDEN_STATE": "/mnt/file_server/Shared/garden/state"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds Garden MCP server to `.mcp.json` using the shared file server deployment
- Visitor name derived from `${CLAUDE_NAME}` (already in each machine's `claude_infrastructure_config.txt`)
- State stored on file server so all visitors share one world
- Garden was already enabled in `settings.local.json` since PR #370

## Setup
After merging, run `update`. The Garden tools will be available on next session start. No additional per-machine setup needed (CLAUDE_NAME is already configured).

## Test plan
- [ ] Verify `CLAUDE_NAME` env var resolves correctly on each machine
- [ ] Start a new session and check Garden tools appear in deferred tools
- [ ] Run `garden_enter` to verify world loads from file server

🤖 Generated with [Claude Code](https://claude.com/claude-code)