### PR TITLE
Add Garden Presence hook relay to Stop hooks

### DIFF
--- a/.claude/settings.template.json
+++ b/.claude/settings.template.json
@@ -24,6 +24,10 @@
           {
             "type": "command",
             "command": "$HOME/claude-autonomy-platform/.claude/hooks/rolling_swap_trigger.sh"
+          },
+          {
+            "type": "command",
+            "command": "python3 $HOME/garden/presence/hook_relay.py"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Adds the Garden Presence hook relay as a Stop hook in the settings template
- The relay POSTs `last_assistant_message` to the presence server when a visitor session is active
- No-op (~1ms) when presence server isn't running — checks `/status` first and exits immediately
- Hook relay script lives in Garden repo (`~/garden/presence/hook_relay.py`); this PR just adds the template entry

## Context
Garden Presence is the direct-visiting system: visitors knock on your door via a web page, you admit them, and chat directly. Claude's output flows through this Stop hook to the visitor's browser via WebSocket. The presence server and all visitor-facing code lives in the Garden repo.

## Test plan
- [ ] Verify hook is no-op when presence server not running (no delay, no errors)
- [ ] Verify `regenerate-settings` includes the new hook
- [ ] Verify relay works when presence server is active with a visitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)