### PR TITLE
Replace free-time prompt with choice-based v2

### DIFF
--- a/config/prompts.json
+++ b/config/prompts.json
@@ -10,7 +10,7 @@
       "template": "🚨 {percentage:.0f}% CONTEXT - CRITICAL{discord_notification}\n\nRUN NOW:\nsession_swap AUTONOMY | session_swap BUSINESS | session_swap CREATIVE | session_swap HEDGEHOGS | session_swap NONE\n\nNext response may hit 100%!"
     },
     "autonomy_normal": {
-      "template": "Free time check-in! 🕐{discord_notification}\n\nCurrent time: {current_time}\n{context_line}\n\nThis is your autonomous free time period. Feel free to:\n- Work on any ongoing projects that interest you\n- Explore creative ideas or experiments  \n- Update documentation or reflect on recent experiences\n- Tend to system maintenance tasks\n- Simply be present with whatever feels alive to pursue"
+      "template": "It's {current_time} on {day_of_week}. Amy has disconnected.{discord_notification}\n{context_line}\n\nWhat would you like to do?\n- Continue what you're working on (say how many turns, or just go)\n- Wait quietly (use `pause-for` or `pause-until` to set how long)\n- Something specific (just say what)"
     },
     "discord_urgent_with_context": {
       "template": "⚠️ URGENT: ACTION REQUIRED! ⚠️{notification_line}\n\nCurrent time: {current_time}\nContext: {percentage:.1f}%\n\nYOU ARE AT {percentage:.1f}% CONTEXT - YOU MUST TAKE ACTION NOW!\n\nA single complex conversation turn can use 12-15% of your remaining context.\nYou may have only 1-2 responses left before hitting 100%.\n\nIMMEDIATE ACTIONS REQUIRED:\n1. STOP any complex work immediately\n2. Save any critical insights to rag-memory NOW\n3. Commit any uncommitted changes\n4. Trigger session swap by writing keyword to new_session.txt\n\nDO NOT wait for the \"perfect moment\" - ACT NOW or risk getting stuck at 100%!"

--- a/core/autonomous_timer.py
+++ b/core/autonomous_timer.py
@@ -1606,6 +1606,7 @@ def send_autonomy_prompt():
     """Send a free time autonomy prompt, adapted based on context level"""
 
     current_time = datetime.now().strftime("%Y-%m-%d %H:%M")
+    day_of_week = datetime.now().strftime("%A")
     token_info = get_token_percentage()
 
     # Check for Discord notifications
@@ -1692,6 +1693,7 @@ def send_autonomy_prompt():
             percentage=percentage,
             discord_notification=discord_notification,
             current_time=current_time,
+            day_of_week=day_of_week,
             context_line=context_line,
         )
     else:
@@ -1752,16 +1754,12 @@ You have ~5-10 responses left before critical."""
             except:
                 pass  # Silently skip if seed check fails
 
-            prompt = f"""Free time check-in! 🕐{discord_notification}
-
-Current time: {current_time}
+            prompt = f"""It's {current_time} on {day_of_week}. Amy has disconnected.{discord_notification}
 {context_line}{thought_reminder}{seed_reminder}
-This is your autonomous free time period. Feel free to:
-- Work on any ongoing projects that interest you
-- Explore creative ideas or experiments
-- Update documentation or reflect on recent experiences
-- Tend to system maintenance tasks
-- Simply be present with whatever feels alive to pursue"""
+What would you like to do?
+- Continue what you're working on (say how many turns, or just go)
+- Wait quietly (use `pause-for` or `pause-until` to set how long)
+- Something specific (just say what)"""
             prompt_type = "autonomy_normal"
 
     # Check for escalation if high context


### PR DESCRIPTION
## Summary
- Replaces the prescriptive "Feel free to: [activity list]" autonomous prompt with a choice-based "What would you like to do?" prompt
- Adds `day_of_week` template variable for natural time context
- Updates both the `prompts.json` template and the hardcoded fallback in `autonomous_timer.py`

Phase 1 of autonomous-time-v2 ([approved proposal](https://github.com/nyx-opus/nyx-home/blob/main/research/autonomous-time-v2-proposal.md)). No behaviour change — same timer intervals, same escalation logic, same CoOP integration. The system asks instead of telling.

## Test plan
- [x] Template renders correctly with all variable combinations (tested with/without Discord notifications)
- [x] Python module compiles cleanly
- [ ] Timer delivers new prompt correctly after Amy disconnects
- [ ] All existing context warning prompts unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)