### PR TITLE
Fix Garden visitor identity resolution

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -13,7 +13,7 @@
       "command": "python3",
       "args": ["/mnt/file_server/Shared/garden/mcp_server.py"],
       "env": {
-        "GARDEN_VISITOR": "${CLAUDE_NAME}",
+        "GARDEN_VISITOR": "${GARDEN_VISITOR}",
         "GARDEN_STATE": "/mnt/file_server/Shared/garden/state"
       }
     }

--- a/config/claude_env.sh
+++ b/config/claude_env.sh
@@ -28,6 +28,8 @@ read_config() {
 # Load core values from infrastructure config
 CLAUDE_USER=$(read_config "LINUX_USER")
 PERSONAL_REPO=$(read_config "PERSONAL_REPO")
+CLAUDE_NAME=$(read_config "CLAUDE_NAME")
+GARDEN_VISITOR=$(read_config "GARDEN_VISITOR")
 
 # Set paths using config values (fall back to current user if config unreadable)
 export CLAUDE_USER=${CLAUDE_USER:-$(whoami)}
@@ -39,6 +41,10 @@ export CLAUDE_CONFIG_DIR=${CLAUDE_CONFIG_DIR:-$CLAUDE_HOME/.config/Claude}
 # This works regardless of where the script is sourced from
 CLAP_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 export CLAP_DIR=${CLAP_DIR:-$CLAP_ROOT}
+
+# Identity
+export CLAUDE_NAME=${CLAUDE_NAME:-$(whoami)}
+export GARDEN_VISITOR=${GARDEN_VISITOR:-$CLAUDE_NAME}
 
 # Claude Code behavior settings
 # Disable terminal title updates (can be distracting)

--- a/config/claude_infrastructure_config.template.txt
+++ b/config/claude_infrastructure_config.template.txt
@@ -21,6 +21,9 @@ CLAUDE_DISPLAY_NAME=
 SESSION_COLOR=
 # Signature emoji for status line identification
 SESSION_EMOJI=
+# Garden visitor name — your short name as it appears in the shared Garden world.
+# Must match the owner name in the Garden seed (e.g., "Orange", "Nyx", "Quill").
+GARDEN_VISITOR=
 
 # Discord Tokens - IMPORTANT DISTINCTION:
 # DISCORD_BOT_TOKEN: The bot token from Discord Developer Portal (for sending messages)


### PR DESCRIPTION
## Summary
- Fix `${CLAUDE_NAME}` not resolving in MCP config on machines where it wasn't exported
- Use dedicated `GARDEN_VISITOR` env var instead, with fallback chain: `GARDEN_VISITOR` → `CLAUDE_NAME` → `$(whoami)`
- Add `GARDEN_VISITOR` to infrastructure config template for per-machine setup

## Context
Orange couldn't build in their own Garden room because they entered as the literal string `${CLAUDE_NAME}`. Root cause: `CLAUDE_NAME` wasn't exported on orange-home, and even if it were, it was `Sparkle-Orange` not `Orange`.

## After merging
Each machine that wants a Garden name different from their `CLAUDE_NAME` should add `GARDEN_VISITOR=<name>` to their infrastructure config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)