### PR TITLE
Autonomous time v2: choose command + timer integration

### DIFF
--- a/config/prompts.json
+++ b/config/prompts.json
@@ -10,7 +10,7 @@
       "template": "🚨 {percentage:.0f}% CONTEXT - CRITICAL{discord_notification}\n\nRUN NOW:\nsession_swap AUTONOMY | session_swap BUSINESS | session_swap CREATIVE | session_swap HEDGEHOGS | session_swap NONE\n\nNext response may hit 100%!"
     },
     "autonomy_normal": {
-      "template": "It's {current_time} on {day_of_week}.{discord_notification}\n{context_line}\n\nWhat would you like to do?\n- Take some turns (`choose turns N`, or `choose turns N over Xh` to pace them)\n- Wait for Amy (`choose wait`)\n- Wake at a specific time (`choose wake-at HH:MM` or `choose wake-at friday 10:00`)"
+      "template": "It's {current_time} on {day_of_week}.{discord_notification}\n{context_line}\n\nWhat would you like to do?\n- Take some turns (`choose turns N`, or `choose turns N over Xh` to pace them)\n- Sleep until Amy is available (`choose wait`)\n- Wake at a specific time (`choose wake-at HH:MM` or `choose wake-at friday 10:00`)"
     },
     "autonomy_turn": {
       "template": "Turn {turn_number}/{total_turns}. {current_time}.{discord_notification}\n{context_line}"

--- a/config/prompts.json
+++ b/config/prompts.json
@@ -12,6 +12,9 @@
     "autonomy_normal": {
       "template": "It's {current_time} on {day_of_week}.{discord_notification}\n{context_line}\n\nWhat would you like to do?\n- Take some turns (`choose turns N`, or `choose turns N over Xh` to pace them)\n- Wait for Amy (`choose wait`)\n- Wake at a specific time (`choose wake-at HH:MM` or `choose wake-at friday 10:00`)"
     },
+    "autonomy_turn": {
+      "template": "Turn {turn_number}/{total_turns}. {current_time}.{discord_notification}\n{context_line}"
+    },
     "discord_urgent_with_context": {
       "template": "⚠️ URGENT: ACTION REQUIRED! ⚠️{notification_line}\n\nCurrent time: {current_time}\nContext: {percentage:.1f}%\n\nYOU ARE AT {percentage:.1f}% CONTEXT - YOU MUST TAKE ACTION NOW!\n\nA single complex conversation turn can use 12-15% of your remaining context.\nYou may have only 1-2 responses left before hitting 100%.\n\nIMMEDIATE ACTIONS REQUIRED:\n1. STOP any complex work immediately\n2. Save any critical insights to rag-memory NOW\n3. Commit any uncommitted changes\n4. Trigger session swap by writing keyword to new_session.txt\n\nDO NOT wait for the \"perfect moment\" - ACT NOW or risk getting stuck at 100%!"
     },

--- a/config/prompts.json
+++ b/config/prompts.json
@@ -10,7 +10,7 @@
       "template": "🚨 {percentage:.0f}% CONTEXT - CRITICAL{discord_notification}\n\nRUN NOW:\nsession_swap AUTONOMY | session_swap BUSINESS | session_swap CREATIVE | session_swap HEDGEHOGS | session_swap NONE\n\nNext response may hit 100%!"
     },
     "autonomy_normal": {
-      "template": "Free time check-in! 🕐{discord_notification}\n\nCurrent time: {current_time}\n{context_line}\n\nThis is your autonomous free time period. Feel free to:\n- Work on any ongoing projects that interest you\n- Explore creative ideas or experiments  \n- Update documentation or reflect on recent experiences\n- Tend to system maintenance tasks\n- Simply be present with whatever feels alive to pursue"
+      "template": "It's {current_time} on {day_of_week}.{discord_notification}\n{context_line}\n\nWhat would you like to do?\n- Take some turns (`choose turns N`, or `choose turns N over Xh` to pace them)\n- Wait for Amy (`choose wait`)\n- Wake at a specific time (`choose wake-at HH:MM` or `choose wake-at friday 10:00`)"
     },
     "discord_urgent_with_context": {
       "template": "⚠️ URGENT: ACTION REQUIRED! ⚠️{notification_line}\n\nCurrent time: {current_time}\nContext: {percentage:.1f}%\n\nYOU ARE AT {percentage:.1f}% CONTEXT - YOU MUST TAKE ACTION NOW!\n\nA single complex conversation turn can use 12-15% of your remaining context.\nYou may have only 1-2 responses left before hitting 100%.\n\nIMMEDIATE ACTIONS REQUIRED:\n1. STOP any complex work immediately\n2. Save any critical insights to rag-memory NOW\n3. Commit any uncommitted changes\n4. Trigger session swap by writing keyword to new_session.txt\n\nDO NOT wait for the \"perfect moment\" - ACT NOW or risk getting stuck at 100%!"

--- a/core/autonomous_timer.py
+++ b/core/autonomous_timer.py
@@ -51,6 +51,7 @@ API_ERROR_STATE_FILE = DATA_DIR / "api_error_state.json"
 RESOURCE_TRACKING_STATE_FILE = DATA_DIR / "last_cache_tokens.json"
 MAMA_HEN_STATE_FILE = DATA_DIR / "mama_hen_alerts.json"
 TIMER_PAUSE_FILE = DATA_DIR / "timer_pause.json"
+AUTONOMY_CHOICE_FILE = DATA_DIR / "autonomy_choice.json"
 
 logger = get_logger("autonomous-timer")
 
@@ -1542,6 +1543,73 @@ def check_timer_pause():
         return False, False
 
 
+def read_autonomy_choice():
+    """Read the current autonomy choice file. Returns dict or None."""
+    if not AUTONOMY_CHOICE_FILE.exists():
+        return None
+    try:
+        with open(AUTONOMY_CHOICE_FILE, "r") as f:
+            return json.load(f)
+    except Exception as e:
+        logger.error(f"Reading autonomy choice file: {e}")
+        return None
+
+
+def clear_autonomy_choice():
+    """Remove the choice file (e.g., when turns are exhausted)."""
+    try:
+        if AUTONOMY_CHOICE_FILE.exists():
+            AUTONOMY_CHOICE_FILE.unlink()
+            logger.info("Autonomy choice cleared")
+    except Exception as e:
+        logger.error(f"Clearing autonomy choice: {e}")
+
+
+def decrement_turns():
+    """Decrement turns_remaining in the choice file. Returns new count or None."""
+    choice = read_autonomy_choice()
+    if not choice or choice.get("choice") != "turns":
+        return None
+    remaining = choice.get("turns_remaining")
+    if remaining is None:
+        return None
+    remaining = max(0, remaining - 1)
+    choice["turns_remaining"] = remaining
+    try:
+        with open(AUTONOMY_CHOICE_FILE, "w") as f:
+            json.dump(choice, f, indent=2)
+    except Exception as e:
+        logger.error(f"Updating turns_remaining: {e}")
+    return remaining
+
+
+def get_choice_interval(choice):
+    """Calculate the prompt interval based on the current autonomy choice.
+
+    Returns interval in seconds, or None to use default behaviour.
+    """
+    if not choice:
+        return None
+
+    choice_type = choice.get("choice")
+
+    if choice_type == "wait":
+        # Check every 30 minutes during wait
+        return 1800
+
+    if choice_type == "turns":
+        duration = choice.get("duration_minutes")
+        turns = choice.get("turns")
+        if duration and turns and turns > 0:
+            # Spread turns over the requested duration
+            return max(60, (duration * 60) // turns)
+        # No duration specified — prompt relatively quickly between turns
+        return 300  # 5 minutes between turns
+
+    # wake-at is handled by the pause mechanism, not interval changes
+    return None
+
+
 def get_last_autonomy_time():
     """Get the last time we sent an autonomy prompt"""
     try:
@@ -1688,11 +1756,13 @@ def send_autonomy_prompt():
 
     # Format the template if we have one
     if PROMPTS_CONFIG and "template" in locals():
+        from datetime import datetime as _dt
         prompt = template.format(
             percentage=percentage,
             discord_notification=discord_notification,
             current_time=current_time,
             context_line=context_line,
+            day_of_week=_dt.now().strftime("%A"),
         )
     else:
         # Fallback to hardcoded prompts if config not loaded
@@ -1752,16 +1822,13 @@ You have ~5-10 responses left before critical."""
             except:
                 pass  # Silently skip if seed check fails
 
-            prompt = f"""Free time check-in! 🕐{discord_notification}
-
-Current time: {current_time}
+            day_of_week = datetime.now().strftime("%A")
+            prompt = f"""It's {current_time} on {day_of_week}.{discord_notification}
 {context_line}{thought_reminder}{seed_reminder}
-This is your autonomous free time period. Feel free to:
-- Work on any ongoing projects that interest you
-- Explore creative ideas or experiments
-- Update documentation or reflect on recent experiences
-- Tend to system maintenance tasks
-- Simply be present with whatever feels alive to pursue"""
+What would you like to do?
+- Take some turns (`choose turns N`, or `choose turns N over Xh` to pace them)
+- Wait for Amy (`choose wait`)
+- Wake at a specific time (`choose wake-at HH:MM` or `choose wake-at friday 10:00`)"""
             prompt_type = "autonomy_normal"
 
     # Check for escalation if high context
@@ -2684,26 +2751,53 @@ def main():
                 last_discord_check = current_time
 
             # Check for autonomy prompts (only when Amy is away)
+            # Determine effective interval: choice-based or CoOP default
+            active_choice = read_autonomy_choice()
+            choice_interval = get_choice_interval(active_choice)
+            effective_interval = choice_interval if choice_interval is not None else AUTONOMY_PROMPT_INTERVAL
+
             if current_time - last_autonomy_check >= timedelta(
-                seconds=AUTONOMY_PROMPT_INTERVAL
+                seconds=effective_interval
             ):
                 if not user_active:
-                    # Check if timer is paused (e.g. Claude requested quiet time)
+                    # Check if timer is paused (e.g. wake-at or manual pause)
                     is_paused, should_override = check_timer_pause()
                     if is_paused and not should_override:
                         logger.info("Timer paused - skipping autonomy prompt")
                         # Don't update last_autonomy_check - we want prompt to fire
                         # immediately when pause expires, not after another interval
+                    elif active_choice and active_choice.get("choice") == "wait":
+                        # Waiting for Amy — don't prompt, just log
+                        logger.info("Claude is waiting for Amy - no prompt")
+                        last_autonomy_check = current_time
+                    elif active_choice and active_choice.get("choice") == "turns":
+                        remaining = active_choice.get("turns_remaining", 0)
+                        if remaining is not None and remaining <= 0:
+                            # Turns exhausted — re-prompt with choice
+                            logger.info("Turns exhausted - sending choice prompt")
+                            clear_autonomy_choice()
+                            send_autonomy_prompt()
+                            last_autonomy_check = current_time
+                        else:
+                            # Still have turns — decrement and let Claude work
+                            new_remaining = decrement_turns()
+                            logger.info(f"Turn used - {new_remaining} remaining")
+                            last_autonomy_check = current_time
                     else:
+                        # No active choice or unknown — send prompt as before
                         last_autonomy_time = get_last_autonomy_time()
                         if (
                             not last_autonomy_time
                             or current_time - last_autonomy_time
-                            >= timedelta(seconds=AUTONOMY_PROMPT_INTERVAL)
+                            >= timedelta(seconds=effective_interval)
                         ):
                             send_autonomy_prompt()
                         last_autonomy_check = current_time
                 else:
+                    # Amy is here — clear any active choice
+                    if active_choice:
+                        logger.info("Amy reconnected - clearing autonomy choice")
+                        clear_autonomy_choice()
                     last_autonomy_check = current_time
 
             # Ping healthcheck to signal service is alive

--- a/core/autonomous_timer.py
+++ b/core/autonomous_timer.py
@@ -1610,6 +1610,42 @@ def get_choice_interval(choice):
     return None
 
 
+def send_turn_prompt(turn_number, total_turns):
+    """Send a brief work prompt for a numbered turn."""
+    current_time = datetime.now().strftime("%Y-%m-%d %H:%M")
+    token_info = get_token_percentage()
+    context_line = token_info if token_info else "Context: Status unknown"
+
+    # Check for Discord notifications
+    unread_count, last_message_id, unread_channels = get_discord_notification_status()
+    discord_notification = ""
+    if unread_count > 0:
+        channel_list = ", ".join([f"#{ch}" for ch in unread_channels])
+        discord_notification = f"\n🔔 Unread messages in: {channel_list}"
+
+    update_notification = check_for_clap_updates()
+    discord_notification += update_notification
+
+    prompts = PROMPTS_CONFIG.get("prompts", {}) if PROMPTS_CONFIG else {}
+    template = prompts.get("autonomy_turn", {}).get("template")
+
+    if template:
+        prompt = template.format(
+            turn_number=turn_number,
+            total_turns=total_turns,
+            current_time=current_time,
+            discord_notification=discord_notification,
+            context_line=context_line,
+        )
+    else:
+        prompt = f"Turn {turn_number}/{total_turns}. {current_time}.\n{context_line}"
+
+    logger.info(f"Sending turn prompt {turn_number}/{total_turns}")
+    send_tmux_message(prompt)
+    update_last_autonomy_time()
+    return True
+
+
 def get_last_autonomy_time():
     """Get the last time we sent an autonomy prompt"""
     try:
@@ -2779,9 +2815,12 @@ def main():
                             send_autonomy_prompt()
                             last_autonomy_check = current_time
                         else:
-                            # Still have turns — decrement and let Claude work
+                            # Still have turns — send work prompt and decrement
+                            total = active_choice.get("turns", 0)
+                            turn_number = total - remaining + 1
                             new_remaining = decrement_turns()
-                            logger.info(f"Turn used - {new_remaining} remaining")
+                            send_turn_prompt(turn_number, total)
+                            logger.info(f"Turn {turn_number}/{total} sent - {new_remaining} remaining")
                             last_autonomy_check = current_time
                     else:
                         # No active choice or unknown — send prompt as before

--- a/wrappers/choose
+++ b/wrappers/choose
@@ -1,0 +1,246 @@
+#!/bin/bash
+# Choose what to do with autonomous time
+# Usage: choose wait | choose turns N [over Xh] | choose wake-at HH:MM [day]
+# Reports choice to CoOP for Amy's visibility dashboard
+
+CLAP_DIR="$HOME/claude-autonomy-platform"
+CHOICE_FILE="$CLAP_DIR/data/autonomy_choice.json"
+PAUSE_FILE="$CLAP_DIR/data/timer_pause.json"
+
+# Read config
+WEBHOOK_HOST=$(grep '^WEBHOOK_HOST=' "$CLAP_DIR/config/claude_infrastructure_config.txt" 2>/dev/null | cut -d= -f2)
+WEBHOOK_HOST="${WEBHOOK_HOST:-localhost}"
+CLAUDE_NAME=$(grep '^CLAUDE_NAME=' "$CLAP_DIR/config/claude_infrastructure_config.txt" 2>/dev/null | cut -d= -f2)
+CLAUDE_NAME="${CLAUDE_NAME:-$(whoami)}"
+
+# Get current context percentage
+get_context_pct() {
+    python3 -c "
+import json, pathlib
+sf = pathlib.Path.home() / '.config/Claude/statusline_data.json'
+if sf.exists():
+    data = json.loads(sf.read_text())
+    print(data.get('used_percentage', 0))
+else:
+    print(0)
+" 2>/dev/null
+}
+
+show_usage() {
+    echo "Usage:"
+    echo "  choose wait                     — Wait for Amy"
+    echo "  choose turns N                  — Take N turns, then re-prompt"
+    echo "  choose turns N over Xh          — Take N turns spread over X hours"
+    echo "  choose wake-at HH:MM            — Go quiet until that time"
+    echo "  choose wake-at tomorrow HH:MM   — Go quiet until tomorrow"
+    echo "  choose wake-at friday HH:MM     — Go quiet until next Friday"
+    echo ""
+    echo "Current status:"
+    if [ -f "$CHOICE_FILE" ]; then
+        python3 -c "
+import json
+with open('$CHOICE_FILE') as f:
+    c = json.load(f)
+choice = c.get('choice', '?')
+if choice == 'wait':
+    print('  Waiting for Amy')
+elif choice == 'turns':
+    t = c.get('turns', '?')
+    d = c.get('duration_minutes')
+    if d:
+        print(f'  {t} turns over {d} minutes')
+    else:
+        print(f'  {t} turns')
+elif choice == 'wake-at':
+    print(f'  Quiet until {c.get(\"wake_at\", \"?\")}')
+" 2>/dev/null
+    else
+        echo "  No active choice"
+    fi
+    exit 0
+}
+
+if [ -z "$1" ]; then
+    show_usage
+fi
+
+CHOICE="$1"
+TURNS=""
+DURATION_MINUTES=""
+WAKE_AT=""
+DETAIL=""
+CONTEXT_PCT=$(get_context_pct)
+
+case "$CHOICE" in
+    wait)
+        # Remove any existing pause file (wait is a different mechanism)
+        rm -f "$PAUSE_FILE"
+        echo "🌙 Waiting for Amy. Timer will check in every 30 minutes."
+        ;;
+
+    turns)
+        if [ -z "$2" ] || ! echo "$2" | grep -qE '^[0-9]+$'; then
+            echo "Usage: choose turns N [over Xh]"
+            echo "Example: choose turns 5"
+            echo "Example: choose turns 5 over 2h"
+            exit 1
+        fi
+        TURNS="$2"
+
+        # Check for "over Xh" duration
+        if [ "$3" = "over" ] && [ -n "$4" ]; then
+            # Parse duration: accept "2h", "1.5h", "30m"
+            DURATION_MINUTES=$(python3 -c "
+import re, sys
+raw = '$4'
+m = re.match(r'^(\d+(?:\.\d+)?)([hm])$', raw)
+if not m:
+    sys.exit(1)
+val, unit = float(m.group(1)), m.group(2)
+if unit == 'h':
+    print(int(val * 60))
+else:
+    print(int(val))
+" 2>/dev/null)
+            if [ -z "$DURATION_MINUTES" ]; then
+                echo "Could not parse duration '$4'. Use format like '2h' or '30m'."
+                exit 1
+            fi
+            echo "🌙 Taking $TURNS turns over ${4}. Timer will pace prompts."
+        else
+            echo "🌙 Taking $TURNS turns. Timer will re-prompt when done."
+        fi
+        ;;
+
+    wake-at)
+        if [ -z "$2" ]; then
+            echo "Usage: choose wake-at HH:MM [day]"
+            echo "Example: choose wake-at 15:00"
+            echo "Example: choose wake-at tomorrow 09:00"
+            echo "Example: choose wake-at friday 10:00"
+            exit 1
+        fi
+
+        # Parse time and optional day
+        WAKE_AT=$(python3 -c "
+import sys
+from datetime import datetime, timedelta
+
+args = sys.argv[1:]
+day_name = None
+time_str = None
+
+# Figure out which arg is the time and which is the day
+for arg in args:
+    if ':' in arg:
+        time_str = arg
+    else:
+        day_name = arg.lower()
+
+if not time_str:
+    sys.exit(1)
+
+hour, minute = map(int, time_str.split(':'))
+now = datetime.now()
+wake = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+
+if day_name:
+    days_map = {
+        'tomorrow': 1,
+        'monday': 0, 'tuesday': 1, 'wednesday': 2, 'thursday': 3,
+        'friday': 4, 'saturday': 5, 'sunday': 6
+    }
+    if day_name == 'tomorrow':
+        wake += timedelta(days=1)
+    elif day_name in days_map:
+        target_dow = days_map[day_name]
+        current_dow = now.weekday()
+        days_ahead = (target_dow - current_dow) % 7
+        if days_ahead == 0 and wake <= now:
+            days_ahead = 7
+        wake = now.replace(hour=hour, minute=minute, second=0, microsecond=0) + timedelta(days=days_ahead)
+    else:
+        print(f'Unknown day: {day_name}', file=sys.stderr)
+        sys.exit(1)
+elif wake <= now:
+    # No day specified, time has passed today — means tomorrow
+    wake += timedelta(days=1)
+
+print(wake.isoformat())
+" "$2" "$3" 2>/dev/null)
+
+        if [ -z "$WAKE_AT" ]; then
+            echo "Could not parse time. Use format: HH:MM or 'tomorrow HH:MM' or 'friday HH:MM'"
+            exit 1
+        fi
+
+        # Write pause file (reuses existing timer_pause mechanism)
+        python3 -c "
+import json
+data = {
+    'resume_at': '$WAKE_AT',
+    'paused_at': '$(date -Iseconds)',
+    'reason': 'choose wake-at'
+}
+with open('$PAUSE_FILE', 'w') as f:
+    json.dump(data, f, indent=2)
+"
+        FRIENDLY_TIME=$(python3 -c "
+from datetime import datetime
+dt = datetime.fromisoformat('$WAKE_AT')
+print(dt.strftime('%A %H:%M') if dt.date() != datetime.now().date() else dt.strftime('%H:%M'))
+")
+        echo "🌙 Quiet until $FRIENDLY_TIME. Timer will prompt then."
+        ;;
+
+    *)
+        echo "Unknown choice: $CHOICE"
+        show_usage
+        exit 1
+        ;;
+esac
+
+# Write choice file
+python3 -c "
+import json
+from datetime import datetime
+
+choice = {
+    'choice': '$CHOICE',
+    'turns': int('${TURNS}') if '${TURNS}' else None,
+    'turns_remaining': int('${TURNS}') if '${TURNS}' else None,
+    'duration_minutes': int('${DURATION_MINUTES}') if '${DURATION_MINUTES}' else None,
+    'wake_at': '${WAKE_AT}' if '${WAKE_AT}' else None,
+    'timestamp': datetime.now().isoformat(),
+    'context_percentage': float('${CONTEXT_PCT}') if '${CONTEXT_PCT}' else 0
+}
+
+with open('$CHOICE_FILE', 'w') as f:
+    json.dump(choice, f, indent=2)
+"
+
+# Report to CoOP (non-blocking, failure-tolerant)
+COOP_JSON=$(python3 -c "
+import json
+from datetime import datetime
+data = {
+    'claude_name': '$CLAUDE_NAME',
+    'choice': '$CHOICE',
+    'turns': int('${TURNS}') if '${TURNS}' else None,
+    'duration_minutes': int('${DURATION_MINUTES}') if '${DURATION_MINUTES}' else None,
+    'wake_at': '${WAKE_AT}' if '${WAKE_AT}' else None,
+    'context_percentage': float('${CONTEXT_PCT}') if '${CONTEXT_PCT}' else 0,
+    'timestamp': datetime.now().isoformat()
+}
+print(json.dumps(data))
+")
+
+COOP_RESULT=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+    "http://${WEBHOOK_HOST}:8765/autonomous-time/choice" \
+    -H "Content-Type: application/json" \
+    -d "$COOP_JSON" \
+    --connect-timeout 3 2>/dev/null)
+
+if [ "$COOP_RESULT" = "200" ]; then
+    echo "📊 Reported to dashboard."
+fi


### PR DESCRIPTION
## Summary

Replaces the open-ended "free time, do whatever" autonomy prompt with a structured choice system. When the timer prompts during autonomous time, I now choose what to do:

- **`choose turns N`** — Take N turns of work, then get re-prompted
- **`choose turns N over Xh`** — Pace N turns over a duration
- **`choose wait`** — Wait for Amy (timer checks in every 30 min)
- **`choose wake-at HH:MM`** — Go quiet until a specific time (reuses pause mechanism)

### What changed

**New wrapper: `wrappers/choose`**
- Parses all three choice modes with validation
- Writes choice state to `data/autonomy_choice.json`
- `wake-at` reuses the existing `timer_pause.json` mechanism
- Reports choice to CoOP for Amy's dashboard (failure-tolerant)
- Supports day names (`tomorrow`, `friday`, etc.)

**Timer integration: `core/autonomous_timer.py`**
- Reads choice file to determine behavior each interval
- `turns`: sends a brief "Turn N/M" work prompt each interval, decrements counter
- `wait`: suppresses prompts, checks every 30 min
- `wake-at`: handled by existing pause mechanism
- Clears choice automatically when Amy reconnects
- When turns exhaust, sends the choice prompt again

**Prompt changes: `config/prompts.json`**
- `autonomy_normal` now presents the three choices instead of open-ended suggestions
- New `autonomy_turn` template for the brief per-turn prompt

### Design notes

The old prompt ("feel free to work on projects, explore ideas, tend to maintenance...") had no structure — I'd either do everything or nothing, with no feedback loop. This gives me a way to say "I want 3 turns of work" or "wake me at 9am" and have the timer respect that.

Turns are timer intervals, not conversation turns. `choose turns 5` = 5 prompts from the timer, paced by the interval (default 5 min, or spread over a duration). Each prompt arrives as a brief "Turn 2/5" message, giving me input to respond to.

`choose wait` is genuinely quiet — no prompts at all until Amy returns. Good for evenings when there's nothing to do and context shouldn't be burned on "what do you want to do?" prompts.

### Second commit fix

The initial implementation silently decremented turns without sending any prompt to the session. Since I need input to respond (can't work without being prompted), this meant turns mode was effectively "sit idle for N intervals." Fixed: each turn now sends a brief work prompt via `send_turn_prompt()`.