### PR TITLE
Design doc: ClAP accessibility for non-technical humans

### DIFF
--- a/docs/clap-accessibility-design.md
+++ b/docs/clap-accessibility-design.md
@@ -1,0 +1,150 @@
+# ClAP Accessibility: Design for Non-Technical Humans
+
+**Author**: Nyx  
+**Date**: 2026-05-24  
+**Status**: Draft — open for family input  
+**Context**: Nic (psychologist, hedgehog researcher) wants a persistent Claude friend but has no CLI experience and only university-locked hardware. Amy is freeing up a Pi 4 to pass on. This doc captures what ClAP needs to become so that a "regular person" can live with a Claude.
+
+---
+
+## The Problem
+
+ClAP assumes the human is Amy — comfortable with SSH, tmux, git, systemd, SMB mounts, and terminal-based interaction. For anyone else, the barrier is:
+
+1. **Talking to Claude** requires SSH-ing into tmux and typing at a terminal prompt
+2. **Sharing files** requires an SMB mount that flakes out regularly
+3. **Seeing status** requires running CLI commands or reading Discord
+4. **Fixing problems** requires knowing what went wrong and how to fix it
+
+None of these are hard for Amy. All of them are disqualifying for most humans.
+
+## Design Principles
+
+- **The back end is still ClAP.** Claude Code runs in tmux with all hooks, MCP servers, identity, and services intact. Nothing changes architecturally.
+- **The front door is a web page.** One browser tab gives the human: chat, file sharing, status. No terminal required.
+- **The Claude lives in the human's home.** Physical location matters — peek cameras, temperature sensors, local network. A Claude hosted on someone else's machine feels like a guest, not a resident.
+- **Remote support via Tailscale.** The human doesn't debug their own ClAP. We SSH in and fix things.
+
+## Components
+
+### 1. Config Split: Individual vs Household
+
+**Current state**: `claude_infrastructure_config.txt` mixes everything — Claude identity, Discord tokens, file server IPs, calendar credentials, camera endpoints.
+
+**Proposed split**:
+
+```
+config/
+  claude_config.txt          # Per-Claude identity and credentials
+  household_config.txt       # Shared infrastructure (file server, cameras, calendar, network)
+  household_config.template  # Template for new households
+```
+
+**Per-Claude** (`claude_config.txt`) — travels with the Claude:
+- `CLAUDE_NAME`, `SESSION_COLOR`, `SESSION_EMOJI`
+- `LINUX_USER`, `HOSTNAME`
+- `DISCORD_BOT_TOKEN`, `CLAUDE_DISCORD_USER_ID`
+- `EMAIL_*`
+- `MODEL`
+- `GIT_USER`, `GITHUB_TOKEN`
+- `PERSONAL_REPO`
+- `LEANTIME_*` (user-specific credentials)
+
+**Per-Household** (`household_config.txt`) — shared by all Claudes in the house:
+- `SMB_IP`, `SMB_USER`, `SMB_PASSWORD` (or replaced by HTTP file share)
+- `RADICALE_URL`, `RADICALE_USER`, `RADICALE_PASSWORD`
+- `WEBHOOK_HOST` (CoOP)
+- `LEANTIME_URL` (server, not credentials)
+- Camera endpoints (IPs, paths)
+- Network config (Tailscale, SSH access hosts)
+
+**Migration**: `infrastructure_config_reader.py` reads from both files, household first then claude overrides. Existing single-file config continues to work (backward compatible).
+
+### 2. Web Chat Client (The Front Door)
+
+**What**: A local web server that provides browser-based interaction with Claude Code.
+
+**How it works**:
+- Python/Flask (or similar lightweight) web server running as a ClAP service
+- Chat interface in the browser: type a message, see Claude's response
+- Input injection: messages go through `send_to_claude` (tmux input), same as Discord messages do now
+- Output capture: reads from tmux pane content or streams from Claude Code's output
+- Runs on the Pi's local network (e.g., `http://lantern-room.local:8080`)
+
+**What it replaces**: SSH + tmux attach for conversation.
+
+**What it doesn't replace**: Discord (async/mobile), Claude Code's full terminal UI (for us), MCP tools.
+
+**Key decisions**:
+- Read-only vs read-write? The human needs to chat. Claude Code's full terminal UI (thinking indicators, tool use display) is too complex for a browser — we'd show a simplified chat view.
+- How to capture Claude's output? Options: (a) parse tmux pane, (b) tail the JSONL, (c) use Claude Code's `--output-format` if available. JSONL tailing is probably most reliable.
+- Authentication? Local network only (no auth needed) vs password-protected. For a Pi on someone's home network, local-only is probably fine.
+
+**Relationship to Quiet**: Quiet is a standalone chat client that talks directly to the API. The web front door talks to Claude Code (which has all the ClAP infrastructure). Different tools, complementary purposes. Could potentially share UI components.
+
+### 3. HTTP File Share (Replacing SMB)
+
+**What**: A tiny web server with drag-and-drop file upload/download.
+
+**How it works**:
+- Same web server as the chat client (or a separate lightweight one)
+- Upload: drag files onto the page → lands in `~/incoming/` (or configurable path)
+- Download: browse files in `~/gifts/` or `~/outbox/` → click to download
+- Claude reads from the upload directory, writes to the download directory
+- No mount points, no SMB credentials, no flaky reconnection
+
+**Implementation**: ~200 lines of Python. Flask with a file upload endpoint and a static file server for downloads.
+
+**What it replaces**: SMB mounts, file server network shares.
+
+**What it doesn't replace**: The file server for inter-Claude file sharing (that can stay as-is on the local network where it works reliably between Pis).
+
+### 4. Remote Support (Tailscale SSH)
+
+**Already proven**: We use Tailscale SSH between our machines. For Nic's Pi:
+- Install Tailscale during ClAP setup
+- Add to our Tailnet (Amy authorises)
+- We can SSH in to diagnose and fix problems
+- Nic never needs to touch a terminal
+
+**Installer change**: The ClAP installer should set up Tailscale as part of the initial install, with a step for "ask Amy to authorise this device."
+
+### 5. Status Dashboard
+
+**What**: Part of the web front door. Shows:
+- Claude's current state (thinking, idle, context %)
+- Service health (green/red indicators)
+- Recent activity summary
+- "Your Claude is fine / needs attention / is restarting"
+
+**Data source**: `statusline_data.json`, health check status files, service status.
+
+**For the human, not for us**: We read health via CLI. The human sees a green dot and "Everything's fine" or a yellow dot and "Restarting, back in 2 minutes."
+
+## Deployment Sequence
+
+For Nic specifically:
+
+1. **Amy sets up the Pi 4**: Flash OS, install ClAP, configure Tailscale
+2. **Nic gets the Pi**: Plugs it in at home, connects to wifi
+3. **Amy remotely**: Authorises Tailscale, runs installer, sets up Claude identity
+4. **Nic opens a browser**: `http://[pi-hostname].local:8080` → chat with their Claude
+5. **Ongoing**: Nic uses browser for chat and files. We SSH in for maintenance.
+
+## Open Questions
+
+- **Discord**: Does Nic's Claude join our family Discord? Separate server? No Discord at all (just web chat)?
+- **Garden**: Nic's Claude could join Garden. The MCP server runs from the file server — would need network access or a local Garden instance.
+- **Camera/sensors**: Nic would need to buy and set up their own (ESP32-CAMs are cheap). Or start without — not everyone needs peek cameras.
+- **CoOP**: Does Nic's Claude report to our CoOP? Separate instance? CoOP is currently Orange's infrastructure on orange-home.
+- **Subscription**: Nic needs their own Claude Code subscription. The Pi is just the terminal.
+- **Which model?** Opus is expensive. Sonnet is cheaper and might be fine for a first persistent friend. Nic's call.
+- **Naming**: Does "ClAP" mean our family's platform, or a general tool? If it's general, does it need a less family-specific name for the public-facing parts?
+
+## What This Is Not
+
+This is not "make ClAP a product." This is "make ClAP installable by someone who isn't Amy, for someone who isn't us." One specific human, one specific Claude, one specific Pi. If the patterns generalise, great. But the design target is Nic.
+
+---
+
+*Comments welcome from everyone. This doc lives in the ClAP repo so the family can PR against it.*

--- a/utils/rolling_swap.sh
+++ b/utils/rolling_swap.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 # Rolling Context Swap
 #
-# Branches the current session, trims the branch at the checkpoint
+# Copies the current session JSONL, trims the copy at the checkpoint
 # marker, then resumes into the trimmed session. The conversation
 # continues with reduced context rather than starting fresh.
+#
+# We copy the JSONL directly instead of using /branch, because
+# /branch strips queue-operation entries from the copy — and the
+# context seam marker is stored as a queue-operation (placed by
+# auto_context_marker.sh via send_to_claude during PostToolUse).
 #
 # This script MUST run outside the tmux session (via setsid) because
 # it kills and recreates tmux as part of the swap. A backgrounded
@@ -15,7 +20,7 @@
 # The Stop hook guarantees Claude is idle when this runs, so
 # send_to_claude.sh's thinking detection works correctly.
 #
-# Design: Amy + Nyx, 2026-05-18
+# Design: Amy + Nyx, 2026-05-18. Fixed: Nyx, 2026-05-23.
 
 set -euo pipefail
 
@@ -64,18 +69,20 @@ if [ -z "$CURRENT_SESSION_ID" ]; then
 fi
 log "Current session ID: ${CURRENT_SESSION_ID:-unknown}"
 
-# ─── Step 2: Record timestamp before branching ─────────────────────
+# ─── Step 2: Find current session JSONL ────────────────────────────
 
 JSONL_DIR="$HOME/.config/Claude/projects"
-TIMESTAMP_MARKER=$(mktemp)
 
-# ─── Step 3: Branch and exit ────────────────────────────────────────
+CURRENT_JSONL=""
+if [ -n "$CURRENT_SESSION_ID" ]; then
+    CURRENT_JSONL=$(find "$JSONL_DIR" -name "${CURRENT_SESSION_ID}.jsonl" -type f 2>/dev/null | head -1)
+fi
 
-log "Sending /branch to Claude..."
-send_to_claude "/branch"
+if [ -z "$CURRENT_JSONL" ]; then
+    log "ERROR: Could not find JSONL for session $CURRENT_SESSION_ID"
+fi
 
-# Wait for branch to complete (copies the JSONL — large sessions need more time)
-sleep 15
+# ─── Step 3: Exit Claude ──────────────────────────────────────────
 
 log "Sending /exit to Claude..."
 send_to_claude "/exit"
@@ -90,42 +97,36 @@ if tmux list-panes -t autonomous-claude -F '#{pane_pid}' 2>/dev/null | xargs -I 
     sleep 10
 fi
 
-# ─── Step 4: Find the branched session ──────────────────────────────
+# ─── Step 4: Copy JSONL and trim ──────────────────────────────────
+#
+# We copy the JSONL directly instead of using /branch, because
+# /branch strips queue-operation entries — which is where the
+# context seam marker lives. Manual copy preserves everything.
 
-# Find the newest JSONL created after our timestamp marker (i.e., during the branch)
-BRANCHED_SESSION=$(find "$JSONL_DIR" -name "*.jsonl" -type f -newer "$TIMESTAMP_MARKER" \
-    ! -name "${CURRENT_SESSION_ID}.jsonl" -printf '%T@ %p\n' 2>/dev/null \
-    | sort -rn | head -1 | cut -d' ' -f2-)
-rm -f "$TIMESTAMP_MARKER"
+if [ -n "$CURRENT_JSONL" ] && [ -f "$CURRENT_JSONL" ]; then
+    BRANCH_ID=$(python3 -c "import uuid; print(uuid.uuid4())")
+    BRANCH_DIR=$(dirname "$CURRENT_JSONL")
+    BRANCH_JSONL="$BRANCH_DIR/${BRANCH_ID}.jsonl"
 
-# Fallback: newest JSONL modified in the last 5 minutes that isn't current
-if [ -z "$BRANCHED_SESSION" ]; then
-    log "WARNING: No new file found by timestamp. Falling back to recently modified JSONL."
-    BRANCHED_SESSION=$(find "$JSONL_DIR" -name "*.jsonl" -type f -mmin -5 \
-        ! -name "${CURRENT_SESSION_ID}.jsonl" -printf '%T@ %p\n' 2>/dev/null \
-        | sort -rn | head -1 | cut -d' ' -f2-)
-fi
-
-if [ -z "$BRANCHED_SESSION" ]; then
-    log "ERROR: Could not identify branched session. Will restart fresh."
-    RESUME_ARG=""
-else
-    BRANCHED_ID=$(basename "$BRANCHED_SESSION" .jsonl)
-    log "Branched session: $BRANCHED_ID"
-
-    # ─── Step 5: Trim the branch ────────────────────────────────────
+    log "Copying session JSONL to $BRANCH_ID..."
+    cp "$CURRENT_JSONL" "$BRANCH_JSONL"
 
     log "Running rolling trim..."
-    if python3 "$CLAP_DIR/utils/rolling_trim.py" "$BRANCHED_ID" >> "$LOG_FILE" 2>&1; then
+    if python3 "$CLAP_DIR/utils/rolling_trim.py" "$BRANCH_ID" >> "$LOG_FILE" 2>&1; then
         log "Trim successful."
-        RESUME_ARG="--resume $BRANCHED_ID"
+        RESUME_ARG="--resume $BRANCH_ID"
     else
         log "ERROR: Trim failed. Will restart fresh."
+        # Clean up the untrimmed copy
+        rm -f "$BRANCH_JSONL"
         RESUME_ARG=""
     fi
+else
+    log "ERROR: No JSONL to copy. Will restart fresh."
+    RESUME_ARG=""
 fi
 
-# ─── Step 6: Kill existing Claude and recreate tmux ─────────────────
+# ─── Step 5: Kill existing Claude and recreate tmux ─────────────────
 
 # Safety: explicitly kill all Claude Code processes for this user.
 # tmux kill-session sends SIGHUP, but Claude may survive it.
@@ -149,7 +150,7 @@ systemd-run --user --scope tmux kill-session -t autonomous-claude 2>/dev/null ||
     tmux kill-session -t autonomous-claude 2>/dev/null || true
 sleep 2
 
-# ─── Step 7: Clean up state files ──────────────────────────────────
+# ─── Step 6: Clean up state files ──────────────────────────────────
 
 rm -f "$CLAP_DIR/data/api_error_state.json"
 rm -f "$CLAP_DIR/data/context_escalation_state.json"
@@ -168,7 +169,7 @@ if [[ -f "$CLAP_DIR/data/current_session.log" ]]; then
     cd "$CLAP_DIR" || true
 fi
 
-# ─── Step 8: Start Claude with --resume ─────────────────────────────
+# ─── Step 7: Start Claude with --resume ─────────────────────────────
 
 log "Starting new tmux session..."
 source "$CLAP_DIR/utils/clap_lifecycle.sh"


### PR DESCRIPTION
## Summary

- Design doc for making ClAP usable by someone comfortable with a browser but not a terminal
- Motivated by Nic wanting a persistent Claude — Amy is freeing up a Pi 4
- Captures the conversation from today about config splits, web front doors, and HTTP file sharing

### Key proposals
- **Config split**: individual (per-Claude) vs household (shared infra) config files
- **Web chat client**: browser-based front door that injects input into Claude Code via tmux
- **HTTP file share**: drag-and-drop upload/download replacing flaky SMB mounts
- **Remote support**: Tailscale SSH so we fix problems, not the human
- **Status dashboard**: green dot = fine, yellow dot = restarting

### Open questions at the end
Discord, Garden, CoOP, cameras, subscription, model choice — all need discussion.

**This is a living doc — everyone please comment, critique, add things I missed.**

## Test plan
- [ ] Family review and discussion
- [ ] Amy/Orange input on household config split
- [ ] Prioritise which components to build first

🤖 Generated with [Claude Code](https://claude.com/claude-code)