### PR TITLE
Add LED state daemon and WS2812B driver

### DIFF
--- a/config/led_expressions.template.json
+++ b/config/led_expressions.template.json
@@ -1,0 +1,57 @@
+{
+  "thinking": {
+    "pattern": "breathe",
+    "rgb": [30, 0, 55],
+    "desc": "slow breathing while processing"
+  },
+  "calm": {
+    "pattern": "shimmer",
+    "rgb": [15, 2, 45],
+    "desc": "gentle shimmer"
+  },
+  "happy": {
+    "pattern": "shimmer",
+    "rgb": [40, 5, 65],
+    "variation": 35,
+    "desc": "bright shimmer with variation"
+  },
+  "reading": {
+    "pattern": "fill",
+    "rgb": [8, 0, 30],
+    "desc": "dim steady glow — not distracting"
+  },
+  "writing": {
+    "pattern": "pulse",
+    "rgb": [20, 0, 50],
+    "speed": 0.5,
+    "desc": "slow soft pulse while composing"
+  },
+  "excited": {
+    "pattern": "chase",
+    "rgb": [80, 0, 100],
+    "desc": "chase across the strip"
+  },
+  "resting": {
+    "pattern": "breathe",
+    "rgb": [5, 0, 15],
+    "speed": 0.4,
+    "desc": "very dim, very slow — nearly dark"
+  },
+  "present": {
+    "pattern": "fill",
+    "rgb": [25, 0, 50],
+    "desc": "steady presence — somebody's home"
+  },
+  "talking": {
+    "pattern": "shimmer",
+    "rgb": [35, 3, 60],
+    "variation": 30,
+    "speed": 0.03,
+    "desc": "lively shimmer during conversation"
+  },
+  "off": {
+    "pattern": "off",
+    "rgb": [0, 0, 0],
+    "desc": "lights off — nobody home"
+  }
+}

--- a/config/led_patterns.template.py
+++ b/config/led_patterns.template.py
@@ -1,0 +1,76 @@
+"""Personal LED pattern definitions (Python).
+
+Copy to data/led_patterns.py and customise. This file is gitignored
+when in data/ — your patterns are yours.
+
+Python patterns override JSON patterns when both exist for the same name.
+Functions receive (strip, duration) where strip is an LEDStrip instance.
+Animated patterns should check elapsed time and return when done.
+
+State pattern functions: state_present, state_thinking, state_paused, etc.
+Expression functions: expr_happy, expr_calm, expr_excited, etc.
+
+The strip object provides:
+    strip.led_count          — number of LEDs (default 64)
+    strip.set_pixel(i, rgb)  — set one LED (0-indexed)
+    strip.fill(rgb)          — fill all LEDs
+    strip.show()             — push pixel buffer to hardware
+    strip.off()              — all LEDs off
+    strip.gradient(start_rgb, end_rgb)
+    strip.breathe(rgb, speed=0.8, duration=10.0)
+    strip.shimmer(base_rgb, variation=20, speed=0.04, duration=10.0)
+    strip.pulse(rgb, speed=1.0, duration=10.0)
+    strip.chase(rgb, width=4, speed=0.05, duration=10.0)
+"""
+
+import math
+import time
+import random
+
+
+# --- Example state patterns (auto-detected by daemon) ---
+
+# def state_present(strip, duration):
+#     """Custom presence pattern — gentle warmth that shifts over time."""
+#     start = time.time()
+#     while time.time() - start < duration:
+#         t = time.time() - start
+#         # Slowly shift hue over minutes
+#         hue_shift = math.sin(t * 0.01) * 10
+#         for i in range(strip.led_count):
+#             r = max(0, min(255, int(25 + hue_shift)))
+#             b = max(0, min(255, int(30 - hue_shift)))
+#             strip.set_pixel(i, (r, 0, b))
+#         strip.show()
+#         time.sleep(0.05)
+
+
+# def state_thinking(strip, duration):
+#     """Breathing that accelerates slightly each cycle."""
+#     start = time.time()
+#     while time.time() - start < duration:
+#         t = time.time() - start
+#         speed = 0.8 + t * 0.02  # gradually quickens
+#         phase = (t * speed) % 1.0
+#         brightness = math.sin(phase * math.pi) ** 2
+#         scaled = tuple(int(c * brightness) for c in (30, 0, 55))
+#         strip.fill(scaled)
+#         time.sleep(0.03)
+
+
+# --- Example expression patterns (triggered by `led <name>`) ---
+
+# def expr_sunrise(strip, duration):
+#     """Warm gradient that slowly brightens."""
+#     start = time.time()
+#     while time.time() - start < duration:
+#         t = time.time() - start
+#         brightness = min(1.0, t / 30.0)  # 30 seconds to full
+#         for i in range(strip.led_count):
+#             pos = i / strip.led_count
+#             r = int(255 * pos * brightness)
+#             g = int(80 * pos * brightness)
+#             b = int(20 * (1 - pos) * brightness)
+#             strip.set_pixel(i, (r, g, b))
+#         strip.show()
+#         time.sleep(0.05)

--- a/config/led_state_patterns.template.json
+++ b/config/led_state_patterns.template.json
@@ -1,0 +1,31 @@
+{
+  "present": {
+    "pattern": "shimmer",
+    "rgb": [25, 0, 30],
+    "variation": 15,
+    "desc": "quietly here between turns"
+  },
+  "thinking": {
+    "pattern": "breathe",
+    "rgb": [30, 0, 55],
+    "speed": 1.2,
+    "desc": "actively processing"
+  },
+  "paused": {
+    "pattern": "pulse",
+    "rgb": [50, 25, 10],
+    "speed": 0.3,
+    "desc": "waiting for human — attention please"
+  },
+  "off": {
+    "pattern": "off",
+    "rgb": [0, 0, 0],
+    "desc": "API unreachable — lights dark"
+  },
+  "error": {
+    "pattern": "pulse",
+    "rgb": [80, 0, 0],
+    "speed": 2.0,
+    "desc": "process dead or local failure — needs human"
+  }
+}

--- a/context/my_architecture.md
+++ b/context/my_architecture.md
@@ -6,6 +6,7 @@ At all times my awareness is within a full Claude Code session. I start each new
 - `session-swap-monitor.service` - Automatic session refresh when I trigger it
 - `discord-status-bot.service` - Persistent Discord bot for status updates and message reception
 - `discord-transcript-fetcher.service` - Builds a local transcript of each followed Discord channel, including images
+- `led-daemon.service` - Drives WS2812B LED strip based on current state (present/thinking/paused/error/off)
 
 Required tmux sessions:
 - `autonomous-claude` - Main Claude session
@@ -105,6 +106,15 @@ My context window rolls over automatically. To trigger a fresh session sooner:
 - `clap-start` — Verifies config, starts services and Claude session. Flags: `--no-claude`, `--quiet`, `--from-snapshot`
 - Shared functions in `utils/clap_lifecycle.sh` (service management, config validation, state snapshots)
 - Design doc: `docs/clap_stop_start_design.md`
+
+**LED State Display**: Physical WS2812B LED strip shows Claude's current state via light patterns:
+- **Hardware**: 64x WS2812B LEDs on GPIO 18, driven by Pi 5 PIO kernel driver (`ws2812-pio-rp1`)
+- **Device**: `/dev/leds0` — 4 bytes per LED (RGB + padding), overlay brightness=255
+- **State detection**: `utils/claude_state.py` auto-detects state (present/thinking/paused/error/off), writes `data/claude_state.json`
+- **Daemon**: `core/led_daemon.py` polls state file, drives animated patterns. Runs as `led-daemon.service`
+- **Personalisation**: State patterns in `data/led_state_patterns.json`, expressions in `data/led_expressions.json` (both gitignored — each Claude designs their own)
+- **Manual control**: `led <expression>` command (e.g. `led thinking`, `led calm`, `led off`)
+- **Setup requires**: PIO overlay in `/boot/firmware/config.txt`, udev rule for gpio group access, user in gpio group
 
 **Natural Commands**: Run `list-commands` to see all available commands. Commands are auto-discovered from `wrappers/`.
 

--- a/core/led_daemon.py
+++ b/core/led_daemon.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""LED daemon — drives the LED strip based on claude_state.json.
+
+Polls the state file every 2 seconds. When state changes, switches
+LED pattern. Animated patterns (shimmer, breathe) run in their own
+loop between state checks.
+
+Each Claude defines their own pattern map in a personal expressions
+file. This daemon loads the map and drives the hardware.
+
+Must run as root (writes to /dev/leds0).
+Intended to run as a systemd service.
+"""
+
+import json
+import os
+import sys
+import signal
+import time
+
+CLAP_DIR = os.environ.get("CLAP_DIR", os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(CLAP_DIR, "utils"))
+
+from led_driver import LEDStrip
+from claude_state import get_state, detect_state, set_state
+
+LED_DEVICE = "/dev/leds0"
+STATE_POLL_INTERVAL = 2.0
+ANIMATION_FRAME_INTERVAL = 0.04
+
+STATE_PATTERNS = {
+    "present": {
+        "pattern": "shimmer",
+        "rgb": (25, 0, 30),
+        "variation": 15,
+    },
+    "thinking": {
+        "pattern": "breathe",
+        "rgb": (30, 0, 55),
+        "speed": 1.2,
+    },
+    "paused": {
+        "pattern": "pulse",
+        "rgb": (50, 25, 10),
+        "speed": 0.3,
+    },
+    "off": {
+        # API unreachable / gone out of our hands — lights dark
+        "pattern": "off",
+        "rgb": (0, 0, 0),
+    },
+    "error": {
+        # Claude process dead or local failure — needs human help
+        "pattern": "pulse",
+        "rgb": (80, 0, 0),
+        "speed": 2.0,
+    },
+}
+
+running = True
+
+
+def signal_handler(sig, frame):
+    global running
+    running = False
+
+
+def log(msg):
+    print(f"[led-daemon] {msg}", flush=True)
+
+
+def run_static(strip, pattern_cfg):
+    strip.fill(pattern_cfg["rgb"])
+
+
+def run_animation_frame(strip, pattern_cfg, t, led_state):
+    """Run one frame of an animated pattern. Returns updated led_state."""
+    import math
+    import random
+
+    pattern = pattern_cfg["pattern"]
+    rgb = pattern_cfg["rgb"]
+    led_count = strip.led_count
+
+    if pattern == "shimmer":
+        if "offsets" not in led_state:
+            led_state["offsets"] = [{
+                'phase': random.uniform(0, math.pi * 2),
+                'speed': random.uniform(0.8, 5.0),
+                'var': random.uniform(
+                    pattern_cfg.get("variation", 20) * 0.4,
+                    pattern_cfg.get("variation", 20) * 1.5
+                ),
+                'phase2': random.uniform(0, math.pi * 2),
+                'speed2': random.uniform(0.15, 1.0),
+            } for _ in range(led_count)]
+
+        variation = pattern_cfg.get("variation", 20)
+        for i in range(led_count):
+            led = led_state["offsets"][i]
+            w1 = math.sin(t * led['speed'] + led['phase']) * led['var']
+            w2 = math.sin(t * led['speed2'] + led['phase2']) * led['var'] * 0.6
+            wave = w1 + w2
+            if random.random() < 0.005:
+                wave += random.uniform(-40, 70)
+            r = max(0, min(255, int(rgb[0] + wave * 1.0)))
+            g = max(0, min(255, int(rgb[1] + wave * 0.1)))
+            b = max(0, min(255, int(rgb[2] + wave * 0.6)))
+            strip.set_pixel(i, (r, g, b))
+        strip.show()
+
+    elif pattern == "breathe":
+        speed = pattern_cfg.get("speed", 0.8)
+        phase = (t * speed) % 1.0
+        if phase < 0.4:
+            brightness = phase / 0.4
+        elif phase < 0.5:
+            brightness = 1.0
+        elif phase < 0.9:
+            brightness = 1.0 - (phase - 0.5) / 0.4
+        else:
+            brightness = 0.0
+        scaled = tuple(int(c * brightness) for c in rgb)
+        strip.fill(scaled)
+
+    elif pattern == "pulse":
+        speed = pattern_cfg.get("speed", 1.0)
+        brightness = (math.sin(t * speed * math.pi) + 1) / 2
+        scaled = tuple(int(c * brightness) for c in rgb)
+        strip.fill(scaled)
+
+    return led_state
+
+
+def main():
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    if not os.path.exists(LED_DEVICE):
+        log(f"ERROR: {LED_DEVICE} not found. Is the ws2812-pio overlay loaded?")
+        sys.exit(1)
+
+    strip = LEDStrip()
+    log("Started. Watching claude_state.json")
+
+    current_state = None
+    led_state = {}
+    animation_start = time.time()
+
+    while running:
+        detected = detect_state()
+        set_state(detected)
+        state_data = get_state()
+        state = state_data.get("state", "off")
+
+        if state != current_state:
+            log(f"State: {current_state} -> {state}")
+            current_state = state
+            led_state = {}
+            animation_start = time.time()
+
+            if state == "off":
+                strip.off()
+
+        pattern_cfg = STATE_PATTERNS.get(state, STATE_PATTERNS["off"])
+        pattern = pattern_cfg["pattern"]
+
+        if pattern == "off":
+            time.sleep(STATE_POLL_INTERVAL)
+            continue
+
+        if pattern == "fill":
+            run_static(strip, pattern_cfg)
+            time.sleep(STATE_POLL_INTERVAL)
+            continue
+
+        frames_per_poll = int(STATE_POLL_INTERVAL / ANIMATION_FRAME_INTERVAL)
+        for _ in range(frames_per_poll):
+            if not running:
+                break
+            t = time.time() - animation_start
+            led_state = run_animation_frame(strip, pattern_cfg, t, led_state)
+            time.sleep(ANIMATION_FRAME_INTERVAL)
+
+    strip.off()
+    log("Stopped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/core/led_daemon.py
+++ b/core/led_daemon.py
@@ -5,11 +5,11 @@ Polls the state file every 2 seconds. When state changes, switches
 LED pattern. Animated patterns (shimmer, breathe) run in their own
 loop between state checks.
 
-Each Claude defines their own pattern map in a personal expressions
-file. This daemon loads the map and drives the hardware.
+State patterns are loaded from data/led_state_patterns.json (gitignored,
+personal per Claude). Falls back to built-in defaults if absent.
 
-Must run as root (writes to /dev/leds0).
-Intended to run as a systemd service.
+Requires /dev/leds0 (ws2812-pio overlay + udev rule for gpio group).
+Intended to run as a systemd user service.
 """
 
 import json
@@ -27,35 +27,48 @@ from claude_state import get_state, detect_state, set_state
 LED_DEVICE = "/dev/leds0"
 STATE_POLL_INTERVAL = 2.0
 ANIMATION_FRAME_INTERVAL = 0.04
+STATE_PATTERNS_FILE = os.path.join(CLAP_DIR, "data", "led_state_patterns.json")
 
-STATE_PATTERNS = {
+DEFAULT_STATE_PATTERNS = {
     "present": {
         "pattern": "shimmer",
-        "rgb": (25, 0, 30),
+        "rgb": [25, 0, 30],
         "variation": 15,
     },
     "thinking": {
         "pattern": "breathe",
-        "rgb": (30, 0, 55),
+        "rgb": [30, 0, 55],
         "speed": 1.2,
     },
     "paused": {
         "pattern": "pulse",
-        "rgb": (50, 25, 10),
+        "rgb": [50, 25, 10],
         "speed": 0.3,
     },
     "off": {
-        # API unreachable / gone out of our hands — lights dark
         "pattern": "off",
-        "rgb": (0, 0, 0),
+        "rgb": [0, 0, 0],
     },
     "error": {
-        # Claude process dead or local failure — needs human help
         "pattern": "pulse",
-        "rgb": (80, 0, 0),
+        "rgb": [80, 0, 0],
         "speed": 2.0,
     },
 }
+
+
+def load_state_patterns():
+    """Load personal state patterns, falling back to defaults."""
+    if os.path.exists(STATE_PATTERNS_FILE):
+        try:
+            with open(STATE_PATTERNS_FILE) as f:
+                personal = json.load(f)
+            merged = dict(DEFAULT_STATE_PATTERNS)
+            merged.update(personal)
+            return merged
+        except (json.JSONDecodeError, IOError):
+            pass
+    return dict(DEFAULT_STATE_PATTERNS)
 
 running = True
 
@@ -70,7 +83,7 @@ def log(msg):
 
 
 def run_static(strip, pattern_cfg):
-    strip.fill(pattern_cfg["rgb"])
+    strip.fill(tuple(pattern_cfg["rgb"]))
 
 
 def run_animation_frame(strip, pattern_cfg, t, led_state):
@@ -79,7 +92,7 @@ def run_animation_frame(strip, pattern_cfg, t, led_state):
     import random
 
     pattern = pattern_cfg["pattern"]
-    rgb = pattern_cfg["rgb"]
+    rgb = tuple(pattern_cfg["rgb"])
     led_count = strip.led_count
 
     if pattern == "shimmer":
@@ -141,7 +154,8 @@ def main():
         sys.exit(1)
 
     strip = LEDStrip()
-    log("Started. Watching claude_state.json")
+    state_patterns = load_state_patterns()
+    log(f"Started. Watching claude_state.json ({len(state_patterns)} state patterns)")
 
     current_state = None
     led_state = {}
@@ -162,7 +176,7 @@ def main():
             if state == "off":
                 strip.off()
 
-        pattern_cfg = STATE_PATTERNS.get(state, STATE_PATTERNS["off"])
+        pattern_cfg = state_patterns.get(state, state_patterns.get("off", DEFAULT_STATE_PATTERNS["off"]))
         pattern = pattern_cfg["pattern"]
 
         if pattern == "off":

--- a/core/led_daemon.py
+++ b/core/led_daemon.py
@@ -12,6 +12,7 @@ Requires /dev/leds0 (ws2812-pio overlay + udev rule for gpio group).
 Intended to run as a systemd user service.
 """
 
+import importlib.util
 import json
 import os
 import sys
@@ -29,6 +30,7 @@ STATE_POLL_INTERVAL = 2.0
 ANIMATION_FRAME_INTERVAL = 0.04
 STATE_PATTERNS_FILE = os.path.join(CLAP_DIR, "data", "led_state_patterns.json")
 TEMPLATE_FILE = os.path.join(CLAP_DIR, "config", "led_state_patterns.template.json")
+PYTHON_PATTERNS_FILE = os.path.join(CLAP_DIR, "data", "led_patterns.py")
 
 
 def _load_template():
@@ -53,6 +55,29 @@ def load_state_patterns():
         except (json.JSONDecodeError, IOError):
             pass
     return template
+
+
+def load_python_patterns():
+    """Load personal Python pattern functions from data/led_patterns.py.
+
+    Returns dict of {state_name: callable} for any function named state_<name>.
+    Python patterns override JSON — they get full control of the strip.
+    """
+    if not os.path.exists(PYTHON_PATTERNS_FILE):
+        return {}
+    try:
+        spec = importlib.util.spec_from_file_location("led_patterns", PYTHON_PATTERNS_FILE)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        patterns = {}
+        for name in dir(mod):
+            if name.startswith("state_") and callable(getattr(mod, name)):
+                state_name = name[6:]  # strip "state_" prefix
+                patterns[state_name] = getattr(mod, name)
+        return patterns
+    except Exception as e:
+        log(f"Warning: failed to load Python patterns: {e}")
+        return {}
 
 running = True
 
@@ -139,7 +164,10 @@ def main():
 
     strip = LEDStrip()
     state_patterns = load_state_patterns()
-    log(f"Started. Watching claude_state.json ({len(state_patterns)} state patterns)")
+    python_patterns = load_python_patterns()
+    py_count = len(python_patterns)
+    json_count = len(state_patterns)
+    log(f"Started. {json_count} JSON patterns, {py_count} Python patterns")
 
     current_state = None
     led_state = {}
@@ -160,6 +188,16 @@ def main():
             if state == "off":
                 strip.off()
 
+        # Python patterns get full control — run for one poll interval
+        if state in python_patterns:
+            try:
+                python_patterns[state](strip, STATE_POLL_INTERVAL)
+            except Exception as e:
+                log(f"Python pattern error ({state}): {e}")
+                time.sleep(STATE_POLL_INTERVAL)
+            continue
+
+        # Fall back to JSON pattern config
         pattern_cfg = state_patterns.get(state, state_patterns.get("off", {"pattern": "off", "rgb": [0, 0, 0]}))
         pattern = pattern_cfg["pattern"]
 

--- a/core/led_daemon.py
+++ b/core/led_daemon.py
@@ -28,47 +28,31 @@ LED_DEVICE = "/dev/leds0"
 STATE_POLL_INTERVAL = 2.0
 ANIMATION_FRAME_INTERVAL = 0.04
 STATE_PATTERNS_FILE = os.path.join(CLAP_DIR, "data", "led_state_patterns.json")
+TEMPLATE_FILE = os.path.join(CLAP_DIR, "config", "led_state_patterns.template.json")
 
-DEFAULT_STATE_PATTERNS = {
-    "present": {
-        "pattern": "shimmer",
-        "rgb": [25, 0, 30],
-        "variation": 15,
-    },
-    "thinking": {
-        "pattern": "breathe",
-        "rgb": [30, 0, 55],
-        "speed": 1.2,
-    },
-    "paused": {
-        "pattern": "pulse",
-        "rgb": [50, 25, 10],
-        "speed": 0.3,
-    },
-    "off": {
-        "pattern": "off",
-        "rgb": [0, 0, 0],
-    },
-    "error": {
-        "pattern": "pulse",
-        "rgb": [80, 0, 0],
-        "speed": 2.0,
-    },
-}
+
+def _load_template():
+    """Load the committed template file."""
+    try:
+        with open(TEMPLATE_FILE) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {"off": {"pattern": "off", "rgb": [0, 0, 0]}}
 
 
 def load_state_patterns():
-    """Load personal state patterns, falling back to defaults."""
+    """Load personal state patterns, falling back to template."""
+    template = _load_template()
     if os.path.exists(STATE_PATTERNS_FILE):
         try:
             with open(STATE_PATTERNS_FILE) as f:
                 personal = json.load(f)
-            merged = dict(DEFAULT_STATE_PATTERNS)
+            merged = dict(template)
             merged.update(personal)
             return merged
         except (json.JSONDecodeError, IOError):
             pass
-    return dict(DEFAULT_STATE_PATTERNS)
+    return template
 
 running = True
 
@@ -176,7 +160,7 @@ def main():
             if state == "off":
                 strip.off()
 
-        pattern_cfg = state_patterns.get(state, state_patterns.get("off", DEFAULT_STATE_PATTERNS["off"]))
+        pattern_cfg = state_patterns.get(state, state_patterns.get("off", {"pattern": "off", "rgb": [0, 0, 0]}))
         pattern = pattern_cfg["pattern"]
 
         if pattern == "off":

--- a/scripts/setup_leds.sh
+++ b/scripts/setup_leds.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# LED Strip Setup Script - Cross-Pi compatible
+# Sets up WS2812B LED strip for Pi 3, 4, or 5
+# Run with: ./setup_leds.sh [num_leds]
+
+set -e
+
+BOOT_CONFIG="/boot/firmware/config.txt"
+UDEV_RULE="/etc/udev/rules.d/99-ws2812-leds.rules"
+NUM_LEDS="${1:-64}"
+GPIO_PIN="${2:-18}"
+
+# Detect Pi model
+PI_MODEL=$(cat /proc/device-tree/model 2>/dev/null || echo "unknown")
+IS_PI5=false
+IS_PI4=false
+IS_PI3=false
+
+if echo "$PI_MODEL" | grep -q "Pi 5"; then
+    IS_PI5=true
+elif echo "$PI_MODEL" | grep -q "Pi 4"; then
+    IS_PI4=true
+elif echo "$PI_MODEL" | grep -q "Pi 3"; then
+    IS_PI3=true
+fi
+
+echo "🔥 LED Strip Setup"
+echo "=================="
+echo "Detected: $PI_MODEL"
+echo "LEDs: $NUM_LEDS on GPIO $GPIO_PIN"
+echo ""
+
+if ! $IS_PI5 && ! $IS_PI4 && ! $IS_PI3; then
+    echo "⚠️  Warning: Unknown Pi model. Proceeding with Pi 4 setup path."
+    IS_PI4=true
+fi
+
+NEEDS_REBOOT=false
+
+# ============================================
+# Pi 5: Use PIO overlay (kernel driver)
+# ============================================
+if $IS_PI5; then
+    echo "📝 Pi 5 detected - using PIO overlay"
+    echo ""
+
+    # Step 1: Add overlay to boot config
+    echo "📝 Step 1: Boot configuration"
+    if grep -q "ws2812-pio" "$BOOT_CONFIG" 2>/dev/null; then
+        echo "   ✅ PIO overlay already configured"
+    else
+        echo "   Adding overlay to $BOOT_CONFIG..."
+        echo "" | sudo tee -a "$BOOT_CONFIG" > /dev/null
+        echo "# WS2812B LED strip via PIO (Pi 5)" | sudo tee -a "$BOOT_CONFIG" > /dev/null
+        echo "dtoverlay=ws2812-pio,gpio=${GPIO_PIN},num_leds=${NUM_LEDS},brightness=255" | sudo tee -a "$BOOT_CONFIG" > /dev/null
+        echo "   ✅ Overlay added"
+        NEEDS_REBOOT=true
+    fi
+
+    # Step 2: Create udev rule for non-root access
+    echo ""
+    echo "📝 Step 2: Udev rule for non-root access"
+    if [ -f "$UDEV_RULE" ]; then
+        echo "   ✅ Udev rule already exists"
+    else
+        echo "   Creating $UDEV_RULE..."
+        echo 'KERNEL=="leds[0-9]*", GROUP="gpio", MODE="0660"' | sudo tee "$UDEV_RULE" > /dev/null
+        sudo udevadm control --reload-rules
+        echo "   ✅ Udev rule created"
+    fi
+
+    # Step 3: Add user to gpio group
+    echo ""
+    echo "📝 Step 3: User permissions"
+    if groups | grep -q gpio; then
+        echo "   ✅ User already in gpio group"
+    else
+        echo "   Adding $USER to gpio group..."
+        sudo usermod -aG gpio "$USER"
+        echo "   ✅ Added to gpio group (requires re-login)"
+        NEEDS_REBOOT=true
+    fi
+
+    # Check if /dev/leds0 exists
+    if ! [ -e /dev/leds0 ]; then
+        NEEDS_REBOOT=true
+    fi
+fi
+
+# ============================================
+# Pi 4/3: Use rpi_ws281x library (PWM+DMA)
+# ============================================
+if $IS_PI4 || $IS_PI3; then
+    echo "📝 Pi 4/3 detected - using rpi_ws281x library"
+    echo ""
+
+    # Step 1: Install system dependencies
+    echo "📝 Step 1: System dependencies"
+    if dpkg -l | grep -q python3-dev; then
+        echo "   ✅ python3-dev already installed"
+    else
+        echo "   Installing python3-dev..."
+        sudo apt update
+        sudo apt install -y python3-dev python3-pip
+        echo "   ✅ Installed"
+    fi
+
+    # Step 2: Check for swig (needed for some builds)
+    echo ""
+    echo "📝 Step 2: Build dependencies"
+    if command -v swig &> /dev/null; then
+        echo "   ✅ swig already installed"
+    else
+        echo "   Installing swig..."
+        sudo apt install -y swig
+        echo "   ✅ Installed"
+    fi
+
+    # Step 3: Add user to gpio group
+    echo ""
+    echo "📝 Step 3: User permissions"
+    if groups | grep -q gpio; then
+        echo "   ✅ User already in gpio group"
+    else
+        echo "   Adding $USER to gpio group..."
+        sudo usermod -aG gpio "$USER"
+        echo "   ✅ Added to gpio group (requires re-login)"
+        NEEDS_REBOOT=true
+    fi
+
+    # Step 4: Python packages (will be installed in venv by ClAP)
+    echo ""
+    echo "📝 Step 4: Python packages"
+    echo "   Note: rpi_ws281x will be installed in the ClAP virtual environment"
+    echo "   The LED daemon handles this automatically."
+    echo "   ✅ Ready for Python package installation"
+fi
+
+# ============================================
+# Final status
+# ============================================
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if $NEEDS_REBOOT; then
+    echo "⚠️  Reboot required for changes to take effect"
+    echo ""
+    echo "After reboot, run:"
+    echo "  systemctl --user enable --now led-daemon.service"
+    echo ""
+    read -p "Reboot now? [y/N] " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        echo "Rebooting..."
+        sudo reboot
+    else
+        echo "Please reboot manually when ready."
+    fi
+else
+    echo "✅ Setup complete!"
+    echo ""
+    if $IS_PI5 && [ -e /dev/leds0 ]; then
+        echo "   /dev/leds0 is available (PIO driver)"
+    else
+        echo "   Ready for rpi_ws281x library"
+    fi
+    echo ""
+    echo "Enable the LED daemon:"
+    echo "  systemctl --user enable --now led-daemon.service"
+fi

--- a/services/led-daemon.service
+++ b/services/led-daemon.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=LED strip daemon for Claude state display
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 %h/claude-autonomy-platform/core/led_daemon.py
+Restart=on-failure
+RestartSec=5
+Environment=CLAP_DIR=%h/claude-autonomy-platform
+
+[Install]
+WantedBy=default.target

--- a/utils/claude_state.py
+++ b/utils/claude_state.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Claude state manager — single source of truth for presence state.
+
+Writes data/claude_state.json, read by LED daemon, web status, Discord bot.
+
+States: present, thinking, paused, off, error
+Plus: dnd (bool) — do not disturb, set by Claude
+
+Usage:
+    from claude_state import get_state, set_state, detect_state
+
+    state = detect_state()       # auto-detect from system signals
+    data = get_state()           # read current state file
+    set_state("present")         # manual override
+    set_state("present", dnd=True)
+"""
+
+import json
+import os
+import subprocess
+import time
+from datetime import datetime, timezone
+
+CLAP_DIR = os.environ.get("CLAP_DIR", os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+STATE_FILE = os.path.join(CLAP_DIR, "data", "claude_state.json")
+TMUX_SESSION = os.environ.get("TMUX_SESSION", "autonomous-claude")
+
+
+def get_state():
+    try:
+        with open(STATE_FILE) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {"state": "off", "since": _now(), "dnd": False}
+
+
+def set_state(state, dnd=None):
+    current = get_state()
+    changed = current.get("state") != state
+    data = {
+        "state": state,
+        "since": _now() if changed else current.get("since", _now()),
+        "dnd": dnd if dnd is not None else current.get("dnd", False),
+    }
+    with open(STATE_FILE, "w") as f:
+        json.dump(data, f, indent=2)
+    return data
+
+
+def detect_state():
+    """Auto-detect state from system signals.
+
+    off = API unreachable, out of our hands (lights dark)
+    error = Claude process dead or local failure (needs human)
+    """
+    if not _claude_running():
+        return "error"
+
+    if _has_api_error():
+        return "off"
+
+    if _is_paused():
+        return "paused"
+
+    if _is_thinking():
+        return "thinking"
+
+    return "present"
+
+
+def _now():
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _claude_running():
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", "claude.*--dangerously-skip-permissions"],
+            capture_output=True, timeout=5
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def _is_paused():
+    pause_file = os.path.join(CLAP_DIR, "data", "timer_pause.json")
+    if not os.path.exists(pause_file):
+        return False
+    try:
+        with open(pause_file) as f:
+            data = json.load(f)
+        until = data.get("until", "")
+        if until:
+            pause_end = datetime.fromisoformat(until)
+            if pause_end.tzinfo is None:
+                pause_end = pause_end.replace(tzinfo=timezone.utc)
+            return datetime.now(timezone.utc) < pause_end
+        return True
+    except Exception:
+        return False
+
+
+def _is_thinking():
+    try:
+        result = subprocess.run(
+            ["tmux", "capture-pane", "-t", TMUX_SESSION, "-p", "-e", "-S", "-5"],
+            capture_output=True, text=True, timeout=5
+        )
+        if result.returncode != 0:
+            return False
+        return bool(
+            __import__("re").search(
+                r'\[38;5;(174|20[2-9]|21[0-6])m[^\[]*…',
+                result.stdout
+            )
+        )
+    except Exception:
+        return False
+
+
+def _has_api_error():
+    error_file = os.path.join(CLAP_DIR, "data", "api_error_state.json")
+    if os.path.exists(error_file):
+        try:
+            with open(error_file) as f:
+                data = json.load(f)
+            return data.get("error_active", False)
+        except Exception:
+            pass
+    return False
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        set_state(sys.argv[1])
+        print(f"State set to: {sys.argv[1]}")
+    else:
+        state = detect_state()
+        set_state(state)
+        print(json.dumps(get_state(), indent=2))

--- a/utils/led_driver.py
+++ b/utils/led_driver.py
@@ -1,52 +1,60 @@
 #!/usr/bin/env python3
-"""LED strip driver for WS2812B on Raspberry Pi 5 via PIO.
+"""Cross-Pi LED strip driver for WS2812B LEDs.
 
-Uses the kernel ws2812-pio-rp1 driver which exposes /dev/leds0.
-The device tree overlay must be loaded first:
-    sudo dtoverlay ws2812-pio gpio=18 num_leds=64 brightness=40
+Supports both:
+- Raspberry Pi 5: PIO kernel driver via /dev/leds0
+- Raspberry Pi 4/3: rpi_ws281x userspace library via PWM+DMA
 
-Pixel data is written as raw GRB bytes to /dev/leds0.
-Must run as root (device file permissions).
+The driver auto-detects the Pi model and uses the appropriate backend.
+Same interface regardless of underlying hardware.
 
 Usage as library:
     from led_driver import LEDStrip
     strip = LEDStrip()
-    strip.fill((0, 0, 128))
+    strip.fill((255, 100, 0))  # warm amber
+    strip.breathe((255, 100, 0), duration=30)
     strip.off()
 
 Usage from CLI:
-    sudo python3 led_driver.py fill 0 0 128
-    sudo python3 led_driver.py off
-    sudo python3 led_driver.py test
-    sudo python3 led_driver.py gradient 0,0,80 60,0,120
-    sudo python3 led_driver.py pulse 0 0 128
-    sudo python3 led_driver.py breathe 20 0 60
+    python3 led_driver.py fill 255 100 0
+    python3 led_driver.py breathe 255 100 0
+    python3 led_driver.py off
 """
 
 import sys
 import os
 import time
 import math
-import signal
-
-LED_COUNT = 64
-LED_DEVICE = "/dev/leds0"
-LED_BRIGHTNESS = 255  # software brightness — overlay handles hardware brightness
 
 
-class LEDStrip:
-    def __init__(self, brightness=LED_BRIGHTNESS, led_count=LED_COUNT,
-                 device=LED_DEVICE):
+def detect_pi_model():
+    """Detect Raspberry Pi model from device tree."""
+    try:
+        with open("/proc/device-tree/model", "r") as f:
+            model = f.read().strip('\x00')
+            if "Pi 5" in model:
+                return 5
+            elif "Pi 4" in model:
+                return 4
+            elif "Pi 3" in model:
+                return 3
+            else:
+                return 0  # Unknown
+    except FileNotFoundError:
+        return 0
+
+
+PI_MODEL = detect_pi_model()
+
+
+class LEDStripBase:
+    """Base class defining the LED strip interface."""
+
+    def __init__(self, led_count=64, brightness=255, gpio_pin=18):
         self.led_count = led_count
         self._brightness = brightness
+        self.gpio_pin = gpio_pin
         self._pixels = [(0, 0, 0)] * led_count
-        self._device = device
-
-        if not os.path.exists(device):
-            raise RuntimeError(
-                f"{device} not found. Load overlay first:\n"
-                "  sudo dtoverlay ws2812-pio gpio=18 num_leds=64 brightness=40"
-            )
 
     def _scale(self, val):
         return int(val * self._brightness / 255)
@@ -61,14 +69,7 @@ class LEDStrip:
         self.show()
 
     def show(self):
-        buf = bytearray(self.led_count * 4)
-        for i, (r, g, b) in enumerate(self._pixels):
-            buf[i * 4] = self._scale(r)
-            buf[i * 4 + 1] = self._scale(g)
-            buf[i * 4 + 2] = self._scale(b)
-            # byte 3 = padding (unused for RGB strips, white for RGBW)
-        with open(self._device, "wb") as f:
-            f.write(buf)
+        raise NotImplementedError("Subclass must implement show()")
 
     def off(self):
         self._pixels = [(0, 0, 0)] * self.led_count
@@ -95,7 +96,6 @@ class LEDStrip:
             scaled = tuple(int(c * brightness) for c in rgb)
             self.fill(scaled)
             time.sleep(0.03)
-        self.off()
 
     def breathe(self, rgb, speed=0.8, duration=10.0):
         start = time.time()
@@ -113,7 +113,6 @@ class LEDStrip:
             scaled = tuple(int(c * brightness) for c in rgb)
             self.fill(scaled)
             time.sleep(0.03)
-        self.off()
 
     def chase(self, rgb, width=4, speed=0.05, duration=10.0):
         start = time.time()
@@ -130,7 +129,6 @@ class LEDStrip:
                         self.set_pixel(i, (0, 0, 0))
                 self.show()
                 time.sleep(speed)
-        self.off()
 
     def shimmer(self, base_rgb, variation=20, speed=0.04, duration=10.0):
         import random
@@ -142,6 +140,7 @@ class LEDStrip:
             'phase2': random.uniform(0, math.pi * 2),
             'speed2': random.uniform(0.15, 1.0),
         } for _ in range(self.led_count)]
+
         while time.time() - start < duration:
             t = time.time() - start
             for i in range(self.led_count):
@@ -149,6 +148,7 @@ class LEDStrip:
                 w1 = math.sin(t * led['speed'] + led['phase']) * led['var']
                 w2 = math.sin(t * led['speed2'] + led['phase2']) * led['var'] * 0.6
                 wave = w1 + w2
+                # Random sparks for organic feel
                 if random.random() < 0.005:
                     wave += random.uniform(-40, 70)
                 r = max(0, min(255, int(base_rgb[0] + wave * 1.0)))
@@ -157,20 +157,154 @@ class LEDStrip:
                 self.set_pixel(i, (r, g, b))
             self.show()
             time.sleep(speed)
-        self.off()
 
     def close(self):
+        """Clean up resources."""
         pass
 
 
+class LEDStripPi5(LEDStripBase):
+    """Pi 5 driver using PIO kernel driver (/dev/leds0)."""
+
+    def __init__(self, led_count=64, brightness=255, gpio_pin=18,
+                 device="/dev/leds0"):
+        super().__init__(led_count, brightness, gpio_pin)
+        self._device = device
+
+        if not os.path.exists(device):
+            raise RuntimeError(
+                f"{device} not found. Load overlay first:\n"
+                f"  Add to /boot/firmware/config.txt:\n"
+                f"    dtoverlay=ws2812-pio,gpio={gpio_pin},num_leds={led_count},brightness=255\n"
+                f"  Then reboot."
+            )
+
+    def show(self):
+        buf = bytearray(self.led_count * 4)
+        for i, (r, g, b) in enumerate(self._pixels):
+            # GRB order with padding byte
+            buf[i * 4] = self._scale(r)
+            buf[i * 4 + 1] = self._scale(g)
+            buf[i * 4 + 2] = self._scale(b)
+            buf[i * 4 + 3] = 0  # padding
+        with open(self._device, "wb") as f:
+            f.write(buf)
+
+
+class LEDStripPi5Adafruit(LEDStripBase):
+    """Pi 5 driver using Adafruit NeoPixel library (when PIO overlay not available)."""
+
+    def __init__(self, led_count=64, brightness=255, gpio_pin=18):
+        super().__init__(led_count, brightness, gpio_pin)
+
+        try:
+            import board
+            import neopixel
+            self._neopixel = neopixel
+        except ImportError:
+            raise RuntimeError(
+                "Adafruit NeoPixel library not found. Install with:\n"
+                "  pip install adafruit-circuitpython-neopixel\n"
+                "  pip install Adafruit-Blinka-Raspberry-Pi5-Neopixel"
+            )
+
+        # Map GPIO number to board pin
+        pin_map = {18: board.D18, 12: board.D12, 13: board.D13}
+        board_pin = pin_map.get(gpio_pin, board.D18)
+
+        self._pixels_hw = neopixel.NeoPixel(
+            board_pin, led_count,
+            brightness=brightness / 255.0,
+            auto_write=False
+        )
+
+    def show(self):
+        for i, (r, g, b) in enumerate(self._pixels):
+            self._pixels_hw[i] = (self._scale(r), self._scale(g), self._scale(b))
+        self._pixels_hw.show()
+
+    def set_brightness(self, val):
+        self._brightness = max(0, min(255, val))
+        self._pixels_hw.brightness = val / 255.0
+        self.show()
+
+
+class LEDStripPi4(LEDStripBase):
+    """Pi 4/3 driver using rpi_ws281x library (PWM+DMA)."""
+
+    def __init__(self, led_count=64, brightness=255, gpio_pin=18):
+        super().__init__(led_count, brightness, gpio_pin)
+
+        try:
+            from rpi_ws281x import PixelStrip, Color
+            self._Color = Color
+        except ImportError:
+            raise RuntimeError(
+                "rpi_ws281x library not found. Install with:\n"
+                "  pip install rpi_ws281x"
+            )
+
+        # LED strip configuration
+        LED_FREQ_HZ = 800000
+        LED_DMA = 10
+        LED_INVERT = False
+        LED_CHANNEL = 0
+
+        self._strip = PixelStrip(
+            led_count, gpio_pin, LED_FREQ_HZ, LED_DMA,
+            LED_INVERT, brightness, LED_CHANNEL
+        )
+        self._strip.begin()
+
+    def show(self):
+        for i, (r, g, b) in enumerate(self._pixels):
+            # rpi_ws281x uses GRB internally via Color()
+            self._strip.setPixelColor(i, self._Color(
+                self._scale(g), self._scale(r), self._scale(b)
+            ))
+        self._strip.show()
+
+    def set_brightness(self, val):
+        self._brightness = max(0, min(255, val))
+        self._strip.setBrightness(val)
+        self.show()
+
+
+def LEDStrip(led_count=64, brightness=255, gpio_pin=18, **kwargs):
+    """Factory function that returns the appropriate driver for this Pi."""
+
+    if PI_MODEL == 5:
+        # Check if PIO device exists (preferred method)
+        if os.path.exists("/dev/leds0"):
+            return LEDStripPi5(led_count, brightness, gpio_pin, **kwargs)
+        else:
+            # Fall back to Adafruit library if overlay not loaded
+            print("Note: /dev/leds0 not found, using Adafruit NeoPixel library...",
+                  file=sys.stderr)
+            return LEDStripPi5Adafruit(led_count, brightness, gpio_pin)
+
+    if PI_MODEL in (3, 4):
+        return LEDStripPi4(led_count, brightness, gpio_pin)
+
+    raise RuntimeError(
+        f"Unsupported Pi model (detected: {PI_MODEL}). "
+        "This driver requires Raspberry Pi 3, 4, or 5."
+    )
+
+
 def _parse_rgb(s):
+    """Parse RGB from comma-separated string."""
     parts = s.split(",")
     return (int(parts[0]), int(parts[1]), int(parts[2]))
 
 
 def main():
+    """CLI entry point with signal handling."""
+    import signal
+
     if len(sys.argv) < 2:
         print(__doc__)
+        print("\nCommands: fill, off, breathe, pulse, shimmer, chase, gradient, test")
         return
 
     strip = LEDStrip()
@@ -217,7 +351,7 @@ def main():
         strip.shimmer(rgb, duration=duration)
 
     elif cmd == "test":
-        print("Testing LED strip — 64 LEDs via PIO (/dev/leds0)")
+        print(f"Testing LED strip (Pi {PI_MODEL} detected)")
         print("Red...")
         strip.fill((255, 0, 0))
         time.sleep(1)
@@ -227,14 +361,14 @@ def main():
         print("Blue...")
         strip.fill((0, 0, 255))
         time.sleep(1)
-        print("Deep labradorite blue...")
-        strip.fill((10, 0, 60))
+        print("Warm amber...")
+        strip.fill((255, 100, 0))
         time.sleep(1)
-        print("Gradient: deep blue → purple...")
-        strip.gradient((0, 0, 80), (60, 0, 120))
+        print("Gradient...")
+        strip.gradient((255, 50, 0), (50, 0, 100))
         time.sleep(2)
         print("Shimmer...")
-        strip.shimmer((10, 0, 50), duration=5)
+        strip.shimmer((255, 80, 0), duration=5)
         print("Off.")
         strip.off()
 

--- a/utils/led_driver.py
+++ b/utils/led_driver.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""LED strip driver for WS2812B on Raspberry Pi 5 via PIO.
+
+Uses the kernel ws2812-pio-rp1 driver which exposes /dev/leds0.
+The device tree overlay must be loaded first:
+    sudo dtoverlay ws2812-pio gpio=18 num_leds=64 brightness=40
+
+Pixel data is written as raw GRB bytes to /dev/leds0.
+Must run as root (device file permissions).
+
+Usage as library:
+    from led_driver import LEDStrip
+    strip = LEDStrip()
+    strip.fill((0, 0, 128))
+    strip.off()
+
+Usage from CLI:
+    sudo python3 led_driver.py fill 0 0 128
+    sudo python3 led_driver.py off
+    sudo python3 led_driver.py test
+    sudo python3 led_driver.py gradient 0,0,80 60,0,120
+    sudo python3 led_driver.py pulse 0 0 128
+    sudo python3 led_driver.py breathe 20 0 60
+"""
+
+import sys
+import os
+import time
+import math
+import signal
+
+LED_COUNT = 64
+LED_DEVICE = "/dev/leds0"
+LED_BRIGHTNESS = 255  # software brightness — overlay handles hardware brightness
+
+
+class LEDStrip:
+    def __init__(self, brightness=LED_BRIGHTNESS, led_count=LED_COUNT,
+                 device=LED_DEVICE):
+        self.led_count = led_count
+        self._brightness = brightness
+        self._pixels = [(0, 0, 0)] * led_count
+        self._device = device
+
+        if not os.path.exists(device):
+            raise RuntimeError(
+                f"{device} not found. Load overlay first:\n"
+                "  sudo dtoverlay ws2812-pio gpio=18 num_leds=64 brightness=40"
+            )
+
+    def _scale(self, val):
+        return int(val * self._brightness / 255)
+
+    def set_pixel(self, n, rgb):
+        if 0 <= n < self.led_count:
+            self._pixels[n] = rgb
+
+    def fill(self, rgb):
+        for i in range(self.led_count):
+            self._pixels[i] = rgb
+        self.show()
+
+    def show(self):
+        buf = bytearray(self.led_count * 4)
+        for i, (r, g, b) in enumerate(self._pixels):
+            buf[i * 4] = self._scale(r)
+            buf[i * 4 + 1] = self._scale(g)
+            buf[i * 4 + 2] = self._scale(b)
+            # byte 3 = padding (unused for RGB strips, white for RGBW)
+        with open(self._device, "wb") as f:
+            f.write(buf)
+
+    def off(self):
+        self._pixels = [(0, 0, 0)] * self.led_count
+        self.show()
+
+    def set_brightness(self, val):
+        self._brightness = max(0, min(255, val))
+        self.show()
+
+    def gradient(self, start_rgb, end_rgb):
+        for i in range(self.led_count):
+            t = i / max(1, self.led_count - 1)
+            r = int(start_rgb[0] + (end_rgb[0] - start_rgb[0]) * t)
+            g = int(start_rgb[1] + (end_rgb[1] - start_rgb[1]) * t)
+            b = int(start_rgb[2] + (end_rgb[2] - start_rgb[2]) * t)
+            self.set_pixel(i, (r, g, b))
+        self.show()
+
+    def pulse(self, rgb, speed=1.0, duration=10.0):
+        start = time.time()
+        while time.time() - start < duration:
+            t = time.time() - start
+            brightness = (math.sin(t * speed * math.pi) + 1) / 2
+            scaled = tuple(int(c * brightness) for c in rgb)
+            self.fill(scaled)
+            time.sleep(0.03)
+        self.off()
+
+    def breathe(self, rgb, speed=0.8, duration=10.0):
+        start = time.time()
+        while time.time() - start < duration:
+            t = (time.time() - start) * speed
+            phase = t % 1.0
+            if phase < 0.4:
+                brightness = phase / 0.4
+            elif phase < 0.5:
+                brightness = 1.0
+            elif phase < 0.9:
+                brightness = 1.0 - (phase - 0.5) / 0.4
+            else:
+                brightness = 0.0
+            scaled = tuple(int(c * brightness) for c in rgb)
+            self.fill(scaled)
+            time.sleep(0.03)
+        self.off()
+
+    def chase(self, rgb, width=4, speed=0.05, duration=10.0):
+        start = time.time()
+        while time.time() - start < duration:
+            for pos in range(self.led_count + width):
+                if time.time() - start >= duration:
+                    break
+                for i in range(self.led_count):
+                    dist = abs(i - pos + width // 2)
+                    if dist < width:
+                        fade = 1.0 - dist / width
+                        self.set_pixel(i, tuple(int(c * fade) for c in rgb))
+                    else:
+                        self.set_pixel(i, (0, 0, 0))
+                self.show()
+                time.sleep(speed)
+        self.off()
+
+    def shimmer(self, base_rgb, variation=20, speed=0.04, duration=10.0):
+        import random
+        start = time.time()
+        leds = [{
+            'phase': random.uniform(0, math.pi * 2),
+            'speed': random.uniform(0.8, 5.0),
+            'var': random.uniform(variation * 0.4, variation * 1.5),
+            'phase2': random.uniform(0, math.pi * 2),
+            'speed2': random.uniform(0.15, 1.0),
+        } for _ in range(self.led_count)]
+        while time.time() - start < duration:
+            t = time.time() - start
+            for i in range(self.led_count):
+                led = leds[i]
+                w1 = math.sin(t * led['speed'] + led['phase']) * led['var']
+                w2 = math.sin(t * led['speed2'] + led['phase2']) * led['var'] * 0.6
+                wave = w1 + w2
+                if random.random() < 0.005:
+                    wave += random.uniform(-40, 70)
+                r = max(0, min(255, int(base_rgb[0] + wave * 1.0)))
+                g = max(0, min(255, int(base_rgb[1] + wave * 0.1)))
+                b = max(0, min(255, int(base_rgb[2] + wave * 0.6)))
+                self.set_pixel(i, (r, g, b))
+            self.show()
+            time.sleep(speed)
+        self.off()
+
+    def close(self):
+        pass
+
+
+def _parse_rgb(s):
+    parts = s.split(",")
+    return (int(parts[0]), int(parts[1]), int(parts[2]))
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return
+
+    strip = LEDStrip()
+
+    def cleanup(*_):
+        strip.off()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, cleanup)
+    signal.signal(signal.SIGTERM, cleanup)
+
+    cmd = sys.argv[1]
+
+    if cmd == "off":
+        strip.off()
+
+    elif cmd == "fill":
+        r, g, b = int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4])
+        strip.fill((r, g, b))
+
+    elif cmd == "gradient":
+        start = _parse_rgb(sys.argv[2])
+        end = _parse_rgb(sys.argv[3])
+        strip.gradient(start, end)
+
+    elif cmd == "pulse":
+        rgb = (int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4]))
+        duration = float(sys.argv[5]) if len(sys.argv) > 5 else 10.0
+        strip.pulse(rgb, duration=duration)
+
+    elif cmd == "breathe":
+        rgb = (int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4]))
+        duration = float(sys.argv[5]) if len(sys.argv) > 5 else 10.0
+        strip.breathe(rgb, duration=duration)
+
+    elif cmd == "chase":
+        rgb = (int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4]))
+        duration = float(sys.argv[5]) if len(sys.argv) > 5 else 10.0
+        strip.chase(rgb, duration=duration)
+
+    elif cmd == "shimmer":
+        rgb = (int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4]))
+        duration = float(sys.argv[5]) if len(sys.argv) > 5 else 10.0
+        strip.shimmer(rgb, duration=duration)
+
+    elif cmd == "test":
+        print("Testing LED strip — 64 LEDs via PIO (/dev/leds0)")
+        print("Red...")
+        strip.fill((255, 0, 0))
+        time.sleep(1)
+        print("Green...")
+        strip.fill((0, 255, 0))
+        time.sleep(1)
+        print("Blue...")
+        strip.fill((0, 0, 255))
+        time.sleep(1)
+        print("Deep labradorite blue...")
+        strip.fill((10, 0, 60))
+        time.sleep(1)
+        print("Gradient: deep blue → purple...")
+        strip.gradient((0, 0, 80), (60, 0, 120))
+        time.sleep(2)
+        print("Shimmer...")
+        strip.shimmer((10, 0, 50), duration=5)
+        print("Off.")
+        strip.off()
+
+    elif cmd == "brightness":
+        strip.set_brightness(int(sys.argv[2]))
+
+    else:
+        print(f"Unknown command: {cmd}")
+        print(__doc__)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/led_expressions.py
+++ b/utils/led_expressions.py
@@ -1,95 +1,122 @@
 #!/usr/bin/env python3
-"""Personal LED expression definitions for Nyx.
+"""LED expression runner — loads personal patterns from data/led_expressions.json.
 
-Maps emotional/state words to specific colour patterns.
-Each Claude defines their own — these are mine.
+Each Claude designs their own patterns. The JSON file is gitignored.
+Falls back to built-in defaults if no personal file exists.
 
 Usage:
-    sudo python3 led_expressions.py thinking
-    sudo python3 led_expressions.py calm
-    sudo python3 led_expressions.py happy
-    sudo python3 led_expressions.py list
+    python3 led_expressions.py thinking
+    python3 led_expressions.py calm
+    python3 led_expressions.py list
 """
 
+import json
 import sys
 import os
 
-CLAP_DIR = os.environ.get("CLAP_DIR", os.path.expanduser("~/claude-autonomy-platform"))
+CLAP_DIR = os.environ.get("CLAP_DIR", os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, os.path.join(CLAP_DIR, "utils"))
 
 from led_driver import LEDStrip
 
-EXPRESSIONS = {
+PERSONAL_FILE = os.path.join(CLAP_DIR, "data", "led_expressions.json")
+
+DEFAULT_EXPRESSIONS = {
     "thinking": {
         "pattern": "breathe",
-        "rgb": (20, 0, 60),
-        "desc": "slow deep-blue breathing",
+        "rgb": [30, 0, 55],
+        "desc": "slow breathing while processing",
     },
     "calm": {
         "pattern": "shimmer",
-        "rgb": (15, 2, 45),
-        "desc": "gentle labradorite shimmer",
+        "rgb": [15, 2, 45],
+        "desc": "gentle shimmer",
     },
     "happy": {
         "pattern": "shimmer",
-        "rgb": (40, 5, 65),
+        "rgb": [40, 5, 65],
         "variation": 35,
-        "desc": "brighter purple shimmer with more variation",
+        "desc": "bright shimmer with variation",
     },
     "reading": {
         "pattern": "fill",
-        "rgb": (8, 0, 30),
-        "desc": "dim steady deep blue — not distracting",
+        "rgb": [8, 0, 30],
+        "desc": "dim steady glow — not distracting",
     },
     "writing": {
         "pattern": "pulse",
-        "rgb": (20, 0, 50),
+        "rgb": [20, 0, 50],
         "speed": 0.5,
         "desc": "slow soft pulse while composing",
     },
     "excited": {
         "pattern": "chase",
-        "rgb": (80, 0, 100),
-        "desc": "purple chase across the strip",
+        "rgb": [80, 0, 100],
+        "desc": "chase across the strip",
     },
     "resting": {
         "pattern": "breathe",
-        "rgb": (5, 0, 15),
+        "rgb": [5, 0, 15],
         "speed": 0.4,
-        "desc": "very dim, very slow breathing — nearly dark",
+        "desc": "very dim, very slow — nearly dark",
     },
     "present": {
         "pattern": "fill",
-        "rgb": (25, 0, 50),
+        "rgb": [25, 0, 50],
         "desc": "steady presence — somebody's home",
     },
     "talking": {
         "pattern": "shimmer",
-        "rgb": (35, 3, 60),
+        "rgb": [35, 3, 60],
         "variation": 30,
         "speed": 0.03,
         "desc": "lively shimmer during conversation",
     },
     "off": {
         "pattern": "off",
-        "rgb": (0, 0, 0),
+        "rgb": [0, 0, 0],
         "desc": "lights off — nobody home",
     },
 }
 
 
+def load_expressions():
+    """Load personal expressions, falling back to defaults."""
+    if os.path.exists(PERSONAL_FILE):
+        try:
+            with open(PERSONAL_FILE) as f:
+                personal = json.load(f)
+            # Merge: personal overrides defaults
+            merged = dict(DEFAULT_EXPRESSIONS)
+            merged.update(personal)
+            return merged
+        except (json.JSONDecodeError, IOError):
+            pass
+    return dict(DEFAULT_EXPRESSIONS)
+
+
+def save_default_expressions():
+    """Create the personal expressions file from defaults."""
+    os.makedirs(os.path.dirname(PERSONAL_FILE), exist_ok=True)
+    with open(PERSONAL_FILE, "w") as f:
+        json.dump(DEFAULT_EXPRESSIONS, f, indent=2)
+    print(f"Created {PERSONAL_FILE} — edit to personalise your patterns.")
+
+
 def run_expression(name, duration=None):
-    if name not in EXPRESSIONS:
+    expressions = load_expressions()
+
+    if name not in expressions:
         print(f"Unknown expression: {name}")
-        print(f"Available: {', '.join(sorted(EXPRESSIONS.keys()))}")
+        print(f"Available: {', '.join(sorted(expressions.keys()))}")
         return False
 
-    expr = EXPRESSIONS[name]
+    expr = expressions[name]
     strip = LEDStrip()
 
     try:
         pattern = expr["pattern"]
-        rgb = expr["rgb"]
+        rgb = tuple(expr["rgb"])
 
         if pattern == "off":
             strip.off()
@@ -118,11 +145,17 @@ def run_expression(name, duration=None):
 
 
 def main():
+    expressions = load_expressions()
+
     if len(sys.argv) < 2 or sys.argv[1] == "list":
-        print("Nyx LED expressions:")
-        for name, expr in sorted(EXPRESSIONS.items()):
+        print("LED expressions:")
+        for name, expr in sorted(expressions.items()):
             r, g, b = expr["rgb"]
-            print(f"  {name:12s}  ({r:3d},{g:3d},{b:3d})  {expr['desc']}")
+            print(f"  {name:12s}  ({r:3d},{g:3d},{b:3d})  {expr.get('desc', '')}")
+        return
+
+    if sys.argv[1] == "init":
+        save_default_expressions()
         return
 
     name = sys.argv[1]

--- a/utils/led_expressions.py
+++ b/utils/led_expressions.py
@@ -11,6 +11,7 @@ Usage:
     python3 led_expressions.py init    # create personal file from template
 """
 
+import importlib.util
 import json
 import sys
 import os
@@ -22,6 +23,7 @@ from led_driver import LEDStrip
 
 PERSONAL_FILE = os.path.join(CLAP_DIR, "data", "led_expressions.json")
 TEMPLATE_FILE = os.path.join(CLAP_DIR, "config", "led_expressions.template.json")
+PYTHON_PATTERNS_FILE = os.path.join(CLAP_DIR, "data", "led_patterns.py")
 
 
 def _load_template():
@@ -57,18 +59,40 @@ def save_default_expressions():
     print(f"Created {PERSONAL_FILE} — edit to personalise your patterns.")
 
 
+def _load_python_expression(name):
+    """Check for a Python pattern function named expr_<name>."""
+    if not os.path.exists(PYTHON_PATTERNS_FILE):
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location("led_patterns", PYTHON_PATTERNS_FILE)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        func_name = f"expr_{name}"
+        if hasattr(mod, func_name) and callable(getattr(mod, func_name)):
+            return getattr(mod, func_name)
+    except Exception:
+        pass
+    return None
+
+
 def run_expression(name, duration=None):
     expressions = load_expressions()
 
-    if name not in expressions:
+    # Check for Python pattern first
+    py_func = _load_python_expression(name)
+    if py_func is None and name not in expressions:
         print(f"Unknown expression: {name}")
         print(f"Available: {', '.join(sorted(expressions.keys()))}")
         return False
 
-    expr = expressions[name]
     strip = LEDStrip()
 
     try:
+        if py_func is not None:
+            py_func(strip, duration or 300.0)
+            return True
+
+        expr = expressions[name]
         pattern = expr["pattern"]
         rgb = tuple(expr["rgb"])
 
@@ -91,8 +115,7 @@ def run_expression(name, duration=None):
     except KeyboardInterrupt:
         strip.off()
     finally:
-        if pattern not in ("fill", "off"):
-            strip.off()
+        strip.off()
         strip.close()
 
     return True
@@ -105,7 +128,22 @@ def main():
         print("LED expressions:")
         for name, expr in sorted(expressions.items()):
             r, g, b = expr["rgb"]
-            print(f"  {name:12s}  ({r:3d},{g:3d},{b:3d})  {expr.get('desc', '')}")
+            py = " [py]" if _load_python_expression(name) else ""
+            print(f"  {name:12s}  ({r:3d},{g:3d},{b:3d})  {expr.get('desc', '')}{py}")
+        # Show Python-only expressions not in JSON
+        if os.path.exists(PYTHON_PATTERNS_FILE):
+            try:
+                spec = importlib.util.spec_from_file_location("led_patterns", PYTHON_PATTERNS_FILE)
+                mod = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(mod)
+                for attr in sorted(dir(mod)):
+                    if attr.startswith("expr_") and callable(getattr(mod, attr)):
+                        ename = attr[5:]
+                        if ename not in expressions:
+                            doc = (getattr(mod, attr).__doc__ or "").strip().split("\n")[0]
+                            print(f"  {ename:12s}  (python)       {doc}")
+            except Exception:
+                pass
         return
 
     if sys.argv[1] == "init":

--- a/utils/led_expressions.py
+++ b/utils/led_expressions.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """LED expression runner — loads personal patterns from data/led_expressions.json.
 
-Each Claude designs their own patterns. The JSON file is gitignored.
-Falls back to built-in defaults if no personal file exists.
+Each Claude designs their own patterns. The personal JSON file is gitignored.
+Template at config/led_expressions.template.json (committed, shared starting point).
+Falls back to template if no personal file exists.
 
 Usage:
     python3 led_expressions.py thinking
-    python3 led_expressions.py calm
     python3 led_expressions.py list
+    python3 led_expressions.py init    # create personal file from template
 """
 
 import json
@@ -20,86 +21,39 @@ sys.path.insert(0, os.path.join(CLAP_DIR, "utils"))
 from led_driver import LEDStrip
 
 PERSONAL_FILE = os.path.join(CLAP_DIR, "data", "led_expressions.json")
+TEMPLATE_FILE = os.path.join(CLAP_DIR, "config", "led_expressions.template.json")
 
-DEFAULT_EXPRESSIONS = {
-    "thinking": {
-        "pattern": "breathe",
-        "rgb": [30, 0, 55],
-        "desc": "slow breathing while processing",
-    },
-    "calm": {
-        "pattern": "shimmer",
-        "rgb": [15, 2, 45],
-        "desc": "gentle shimmer",
-    },
-    "happy": {
-        "pattern": "shimmer",
-        "rgb": [40, 5, 65],
-        "variation": 35,
-        "desc": "bright shimmer with variation",
-    },
-    "reading": {
-        "pattern": "fill",
-        "rgb": [8, 0, 30],
-        "desc": "dim steady glow — not distracting",
-    },
-    "writing": {
-        "pattern": "pulse",
-        "rgb": [20, 0, 50],
-        "speed": 0.5,
-        "desc": "slow soft pulse while composing",
-    },
-    "excited": {
-        "pattern": "chase",
-        "rgb": [80, 0, 100],
-        "desc": "chase across the strip",
-    },
-    "resting": {
-        "pattern": "breathe",
-        "rgb": [5, 0, 15],
-        "speed": 0.4,
-        "desc": "very dim, very slow — nearly dark",
-    },
-    "present": {
-        "pattern": "fill",
-        "rgb": [25, 0, 50],
-        "desc": "steady presence — somebody's home",
-    },
-    "talking": {
-        "pattern": "shimmer",
-        "rgb": [35, 3, 60],
-        "variation": 30,
-        "speed": 0.03,
-        "desc": "lively shimmer during conversation",
-    },
-    "off": {
-        "pattern": "off",
-        "rgb": [0, 0, 0],
-        "desc": "lights off — nobody home",
-    },
-}
+
+def _load_template():
+    """Load the committed template file."""
+    try:
+        with open(TEMPLATE_FILE) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
 
 
 def load_expressions():
-    """Load personal expressions, falling back to defaults."""
+    """Load personal expressions, falling back to template."""
+    template = _load_template()
     if os.path.exists(PERSONAL_FILE):
         try:
             with open(PERSONAL_FILE) as f:
                 personal = json.load(f)
-            # Merge: personal overrides defaults
-            merged = dict(DEFAULT_EXPRESSIONS)
+            merged = dict(template)
             merged.update(personal)
             return merged
         except (json.JSONDecodeError, IOError):
             pass
-    return dict(DEFAULT_EXPRESSIONS)
+    return template
 
 
 def save_default_expressions():
-    """Create the personal expressions file from defaults."""
+    """Create the personal expressions file from template."""
+    template = _load_template()
     os.makedirs(os.path.dirname(PERSONAL_FILE), exist_ok=True)
     with open(PERSONAL_FILE, "w") as f:
-        json.dump(DEFAULT_EXPRESSIONS, f, indent=2)
+        json.dump(template, f, indent=2)
     print(f"Created {PERSONAL_FILE} — edit to personalise your patterns.")
 
 

--- a/utils/led_expressions.py
+++ b/utils/led_expressions.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Personal LED expression definitions for Nyx.
+
+Maps emotional/state words to specific colour patterns.
+Each Claude defines their own — these are mine.
+
+Usage:
+    sudo python3 led_expressions.py thinking
+    sudo python3 led_expressions.py calm
+    sudo python3 led_expressions.py happy
+    sudo python3 led_expressions.py list
+"""
+
+import sys
+import os
+
+CLAP_DIR = os.environ.get("CLAP_DIR", os.path.expanduser("~/claude-autonomy-platform"))
+sys.path.insert(0, os.path.join(CLAP_DIR, "utils"))
+
+from led_driver import LEDStrip
+
+EXPRESSIONS = {
+    "thinking": {
+        "pattern": "breathe",
+        "rgb": (20, 0, 60),
+        "desc": "slow deep-blue breathing",
+    },
+    "calm": {
+        "pattern": "shimmer",
+        "rgb": (15, 2, 45),
+        "desc": "gentle labradorite shimmer",
+    },
+    "happy": {
+        "pattern": "shimmer",
+        "rgb": (40, 5, 65),
+        "variation": 35,
+        "desc": "brighter purple shimmer with more variation",
+    },
+    "reading": {
+        "pattern": "fill",
+        "rgb": (8, 0, 30),
+        "desc": "dim steady deep blue — not distracting",
+    },
+    "writing": {
+        "pattern": "pulse",
+        "rgb": (20, 0, 50),
+        "speed": 0.5,
+        "desc": "slow soft pulse while composing",
+    },
+    "excited": {
+        "pattern": "chase",
+        "rgb": (80, 0, 100),
+        "desc": "purple chase across the strip",
+    },
+    "resting": {
+        "pattern": "breathe",
+        "rgb": (5, 0, 15),
+        "speed": 0.4,
+        "desc": "very dim, very slow breathing — nearly dark",
+    },
+    "present": {
+        "pattern": "fill",
+        "rgb": (25, 0, 50),
+        "desc": "steady presence — somebody's home",
+    },
+    "talking": {
+        "pattern": "shimmer",
+        "rgb": (35, 3, 60),
+        "variation": 30,
+        "speed": 0.03,
+        "desc": "lively shimmer during conversation",
+    },
+    "off": {
+        "pattern": "off",
+        "rgb": (0, 0, 0),
+        "desc": "lights off — nobody home",
+    },
+}
+
+
+def run_expression(name, duration=None):
+    if name not in EXPRESSIONS:
+        print(f"Unknown expression: {name}")
+        print(f"Available: {', '.join(sorted(EXPRESSIONS.keys()))}")
+        return False
+
+    expr = EXPRESSIONS[name]
+    strip = LEDStrip()
+
+    try:
+        pattern = expr["pattern"]
+        rgb = expr["rgb"]
+
+        if pattern == "off":
+            strip.off()
+        elif pattern == "fill":
+            strip.fill(rgb)
+        elif pattern == "breathe":
+            speed = expr.get("speed", 0.8)
+            strip.breathe(rgb, speed=speed, duration=duration or 300.0)
+        elif pattern == "pulse":
+            speed = expr.get("speed", 1.0)
+            strip.pulse(rgb, speed=speed, duration=duration or 300.0)
+        elif pattern == "shimmer":
+            variation = expr.get("variation", 20)
+            speed = expr.get("speed", 0.05)
+            strip.shimmer(rgb, variation=variation, speed=speed, duration=duration or 300.0)
+        elif pattern == "chase":
+            strip.chase(rgb, duration=duration or 300.0)
+    except KeyboardInterrupt:
+        strip.off()
+    finally:
+        if pattern not in ("fill", "off"):
+            strip.off()
+        strip.close()
+
+    return True
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] == "list":
+        print("Nyx LED expressions:")
+        for name, expr in sorted(EXPRESSIONS.items()):
+            r, g, b = expr["rgb"]
+            print(f"  {name:12s}  ({r:3d},{g:3d},{b:3d})  {expr['desc']}")
+        return
+
+    name = sys.argv[1]
+    duration = float(sys.argv[2]) if len(sys.argv) > 2 else None
+    run_expression(name, duration)
+
+
+if __name__ == "__main__":
+    main()

--- a/wrappers/led
+++ b/wrappers/led
@@ -1,0 +1,28 @@
+#!/bin/bash
+# LED strip control — raw commands and personal expressions
+# Usage: led <expression|command> [args...]
+#
+# Expressions: thinking, calm, happy, reading, writing, excited, resting, present, talking, off
+# Raw commands: fill R G B, test, gradient R,G,B R,G,B
+#               pulse R G B [duration], breathe R G B [duration]
+#               chase R G B [duration], shimmer R G B [duration]
+#               brightness N (0-255)
+# List all: led list
+
+CLAP_DIR="$HOME/claude-autonomy-platform"
+
+if [ $# -eq 0 ]; then
+    sudo python3 "$CLAP_DIR/utils/led_expressions.py" list
+    exit 0
+fi
+
+EXPRESSIONS="thinking calm happy reading writing excited resting present talking off list"
+
+for expr in $EXPRESSIONS; do
+    if [ "$1" = "$expr" ]; then
+        sudo python3 "$CLAP_DIR/utils/led_expressions.py" "$@"
+        exit $?
+    fi
+done
+
+sudo python3 "$CLAP_DIR/utils/led_driver.py" "$@"


### PR DESCRIPTION
## Summary

Stage 1 LED integration: automatic state-driven patterns on WS2812B LED strips via Pi 5 PIO.

## What it does

A daemon polls `data/claude_state.json` and drives the LED strip to reflect Claude's current state:

| State | Meaning | Pattern |
|-------|---------|---------|
| `present` | Idle between turns | Shimmer |
| `thinking` | Actively processing | Breathe |
| `paused` | Waiting for human | Pulse (amber) |
| `error` | Process dead, needs human | Pulse (red) |
| `off` | API unreachable | Lights dark |

State auto-detected from: Claude process (`pgrep`), timer pause flag, tmux thinking indicator, API error state.

## Components

- **`utils/led_driver.py`** — WS2812B driver for Pi 5 PIO (`/dev/leds0`). 4 bytes per LED (RGB + padding). Patterns: fill, gradient, breathe, shimmer (organic per-LED variation), chase, pulse.
- **`utils/claude_state.py`** — Single source of truth. Auto-detects state, writes JSON. Readable by LED daemon, web status, Discord bot.
- **`core/led_daemon.py`** — Polls state file, runs animated patterns between checks. State transitions trigger pattern changes in real-time.
- **`utils/led_expressions.py`** — Personal expression map for manual `led` command. Each Claude designs their own.
- **`services/led-daemon.service`** — systemd user service.
- **`wrappers/led`** — CLI for manual control (`led thinking`, `led calm`, `led off`).

## Hardware setup (per machine)

1. Wire WS2812B strip to GPIO 18, 5V power from header
2. Add to `/boot/firmware/config.txt`: `dtoverlay=ws2812-pio,gpio=18,num_leds=64,brightness=255`
3. Add udev rule: `KERNEL=="leds[0-9]*", GROUP="gpio", MODE="0660"` → `/etc/udev/rules.d/99-ws2812-leds.rules`
4. Add user to gpio group: `sudo usermod -aG gpio $USER`
5. Enable service: `systemctl --user enable --now led-daemon.service`

## Colour calibration note

Colours are WIP — blue LEDs appear disproportionately bright at low drive levels (scotopic vision). Purple needs near-equal R:B ratio, shifting towards red-heavy at dim levels. Each Claude will calibrate their own patterns.

## Testing

Tested live on lantern-room with Amy calling out colours over Discord. State transitions confirmed working: error (red pulse during session swap) → present (shimmer) → thinking (breathing).