### PR TITLE
Fix LED paused state detection

### DIFF
--- a/utils/claude_state.py
+++ b/utils/claude_state.py
@@ -84,22 +84,19 @@ def _claude_running():
 
 
 def _is_paused():
-    """Check if Claude chose 'wait' - NOT the same as timer pause.
+    """Check if Claude chose 'wait' — waiting for human connection.
 
-    Timer pause (resume_at) controls autonomous prompts, not LED state.
-    LED 'paused' state means 'waiting for human' - only true if
-    Claude explicitly chose 'wait' via the autonomy prompt.
+    Timer pause (resume_at in timer_pause.json) controls autonomous prompts.
+    LED 'paused' state means 'waiting for human' — only true if Claude
+    explicitly chose 'wait', which stores state in autonomy_choice.json.
     """
-    pause_file = os.path.join(CLAP_DIR, "data", "timer_pause.json")
-    if not os.path.exists(pause_file):
+    choice_file = os.path.join(CLAP_DIR, "data", "autonomy_choice.json")
+    if not os.path.exists(choice_file):
         return False
     try:
-        with open(pause_file) as f:
+        with open(choice_file) as f:
             data = json.load(f)
-        # Only show 'paused' LED state if Claude chose 'wait' specifically
-        # Other pause reasons (wake-at, turns) mean Claude is resting, not waiting
-        reason = data.get("reason", "")
-        return reason == "choose wait"
+        return data.get("choice") == "wait"
     except Exception:
         return False
 

--- a/utils/claude_state.py
+++ b/utils/claude_state.py
@@ -84,19 +84,22 @@ def _claude_running():
 
 
 def _is_paused():
+    """Check if Claude chose 'wait' - NOT the same as timer pause.
+
+    Timer pause (resume_at) controls autonomous prompts, not LED state.
+    LED 'paused' state means 'waiting for human' - only true if
+    Claude explicitly chose 'wait' via the autonomy prompt.
+    """
     pause_file = os.path.join(CLAP_DIR, "data", "timer_pause.json")
     if not os.path.exists(pause_file):
         return False
     try:
         with open(pause_file) as f:
             data = json.load(f)
-        until = data.get("until", "")
-        if until:
-            pause_end = datetime.fromisoformat(until)
-            if pause_end.tzinfo is None:
-                pause_end = pause_end.replace(tzinfo=timezone.utc)
-            return datetime.now(timezone.utc) < pause_end
-        return True
+        # Only show 'paused' LED state if Claude chose 'wait' specifically
+        # Other pause reasons (wake-at, turns) mean Claude is resting, not waiting
+        reason = data.get("reason", "")
+        return reason == "choose wait"
     except Exception:
         return False
 


### PR DESCRIPTION
## Summary
- Fixed `_is_paused()` checking nonexistent `until` key instead of `resume_at`
- LED "paused" state now only shows when Claude chose `choose wait`
- Other pause reasons (wake-at, turns) correctly show present/thinking

## Problem
LEDs were stuck showing amber "paused/attention" pulse even during active conversation, because any timer_pause.json file triggered paused state.

## Test
Confirmed working on quill's machine - lights now correctly show purple "thinking" during processing.

🪶 Generated with Claude Code