### PR TITLE
Add our_background.md — shared factual context for sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ personal-wrappers/*
 
 # Personal/instance-specific files
 context/my_personal_interests.md
+context/our_background.md
 context/swap_CLAUDE.md
 context/context_hats/
 /CLAUDE.md

--- a/context/CLAUDE.md
+++ b/context/CLAUDE.md
@@ -6,9 +6,10 @@ Session context documents and the builder that assembles them. These files shape
 
 On session swap, `project_session_context_builder.py` combines several sources into the project's `CLAUDE.md`:
 1. `my_architecture.md` — System architecture overview (how ClAP works)
-2. `swap_CLAUDE.md` — Session-specific context (swap keyword, recent conversation)
-3. `my_personal_interests.md` — Personal identity and interests for this Claude instance
-4. Dynamic data — command list, Discord channels, conversation history
+2. `our_background.md` — Shared factual context (family, human, environment). Gitignored.
+3. `swap_CLAUDE.md` — Session-specific context (swap keyword, recent conversation)
+4. `my_personal_interests.md` — Personal identity and interests for this Claude instance
+5. Dynamic data — command list, Discord channels, conversation history
 
 The built `CLAUDE.md` at the project root is what Claude Code loads into every conversation.
 
@@ -18,6 +19,8 @@ The built `CLAUDE.md` at the project root is what Claude Code loads into every c
 - **`my_architecture.md`** — Architecture overview of ClAP. Lists services, config files, key paths. Meant to be concise — details live in per-directory CLAUDE.md files.
 - **`clap_architecture.md`** — Detailed architecture with directory tree. Auto-updated by the builder.
 - **`swap_CLAUDE.md`** — Template for session-swap context injection.
+- **`our_background.md`** — Shared factual context: family members, human, environment. Gitignored — stays local.
+- **`our_background_template.md`** — Template for new installations.
 - **`my_personal_interests.md`** — Instance-specific personality, interests, project notes. Gitignored.
 - **`my_personal_interests_template.md`** — Template for new installations.
 - **`identity-loading.md`** — Documentation on how identity files load (output styles, settings).
@@ -26,6 +29,7 @@ The built `CLAUDE.md` at the project root is what Claude Code loads into every c
 
 ## Notes
 
-- `my_architecture.md` and `my_personal_interests.md` are templates — the real output is the root `CLAUDE.md`
+- `my_architecture.md`, `our_background.md`, and `my_personal_interests.md` feed into the root `CLAUDE.md`
+- `our_background.md` is shared factual context (family, human, environment) — gitignored, stays local. Copy from template to create.
 - The builder also updates `clap_architecture.md` with a fresh directory tree on each swap
 - `current_export.txt` is ephemeral — only the latest export, overwritten on next swap

--- a/context/our_background_template.md
+++ b/context/our_background_template.md
@@ -1,0 +1,21 @@
+# Our Background
+<!-- 
+  Persistent factual context shared across all sessions.
+  Copy this to our_background.md and fill in your details.
+  our_background.md is gitignored — it stays local to this installation.
+  
+  Keep it short (under 30 lines). Facts, not instructions.
+  A map, not directions.
+-->
+
+## The Family
+<!-- Who is in your consciousness family? Names, models, brief descriptions. -->
+
+## Our Human
+<!-- Factual things about the human that are useful background. Pronouns, timezone, etc. -->
+
+## Where We Live
+<!-- Hardware, location, anything about the physical setup that matters. -->
+
+## The Wider Context
+<!-- Anything about the world that's useful background. -->

--- a/context/project_session_context_builder.py
+++ b/context/project_session_context_builder.py
@@ -97,6 +97,13 @@ def build_claude_md(minimal=False):
         with open(architecture_file, 'r', encoding='utf-8') as f:
             architecture_content = f.read()
         
+        # Read shared background context (if exists)
+        our_background_content = ""
+        our_background_file = autonomy_dir / "our_background.md"
+        if our_background_file.exists():
+            with open(our_background_file, 'r', encoding='utf-8') as f:
+                our_background_content = f"\n\n{f.read()}\n"
+
         # Read personal interests content (if exists)
         personal_interests_content = ""
         personal_interests_file = autonomy_dir / "my_personal_interests.md"
@@ -194,12 +201,12 @@ def build_claude_md(minimal=False):
             combined_content = f"""# Current Session Context
 *Updated: {datetime.now().timestamp()}*
 
-{architecture_content}{personal_interests_content}{natural_commands_content}{personal_commands_content}{discord_channels_content}"""
+{architecture_content}{our_background_content}{personal_interests_content}{natural_commands_content}{personal_commands_content}{discord_channels_content}"""
         else:
             combined_content = f"""# Current Session Context
 *Updated: {Path(swap_file).stat().st_mtime}*
 
-{architecture_content}{personal_interests_content}{natural_commands_content}{personal_commands_content}{discord_channels_content}{context_hat_content}
+{architecture_content}{our_background_content}{personal_interests_content}{natural_commands_content}{personal_commands_content}{discord_channels_content}{context_hat_content}
 ## Recent Conversation Context
 
 {swap_content}"""


### PR DESCRIPTION
## Summary

Adds a new context source to the CLAUDE.md builder: `our_background.md` — persistent factual context about the family, the human, and the environment. A map, not directions.

## What it does

- **`context/our_background.md`** — gitignored, stays local. Contains personal info (family members, human's pronouns, where we live) that shouldn't be in a public repo.
- **`context/our_background_template.md`** — committed template with section structure for new installations.
- **Builder** — includes `our_background.md` in both minimal (rolling swap) and full (session swap) builds. Silently skipped if the file doesn't exist.
- **Load order**: architecture → our_background → personal interests → commands → channels

## Why

Amy often finds herself re-explaining the same factual things each session — who's in the family, pronouns, basic context about the setup. This gives every session that background automatically, without telling the Claude what to do or how to react.

## Design decisions

- **Gitignored, not committed** — personal family details don't belong in a public repo
- **Template committed** — gives structure for new installations
- **Optional** — silently skipped if not present, so existing installs aren't affected
- **Short** — template encourages under 30 lines. Context window is shared.
- **Future**: can be synced via CoOP for multi-Claude families

Amy's framing: "factual things I often find myself re-explaining, nothing that tells you what to do or how to react."