### PR TITLE
Add recall/remember wrappers for rag-memory CLI

### DIFF
--- a/wrappers/recall
+++ b/wrappers/recall
@@ -1,0 +1,8 @@
+#!/bin/bash
+# 🔍 Search your personal knowledge base (rag-memory)
+#
+# Usage: recall <query>
+#   Searches documents and entities by keyword
+#   Example: recall "figurine design"
+#   Example: recall "debate club"
+python3 ~/quiet/rag_cli.py search "$@"

--- a/wrappers/recall-recent
+++ b/wrappers/recall-recent
@@ -1,0 +1,7 @@
+#!/bin/bash
+# 📋 Show recent entries in your knowledge base
+#
+# Usage: recall-recent [count]
+#   Shows the most recent documents (default: 5)
+#   Example: recall-recent 10
+python3 ~/quiet/rag_cli.py recent "$@"

--- a/wrappers/remember
+++ b/wrappers/remember
@@ -1,0 +1,7 @@
+#!/bin/bash
+# 💾 Store something in your personal knowledge base (rag-memory)
+#
+# Usage: remember <title> <content>
+#   Saves a document to long-term memory
+#   Example: remember "session-2026-06-05" "Today we cracked subscription auth..."
+python3 ~/quiet/rag_cli.py store "$@"


### PR DESCRIPTION
## Summary
- Natural command wrappers for the direct rag-memory client (`~/quiet/rag_cli.py`)
- Works from both ccode and Quiet sessions — same PATH, same commands
- `recall <query>` — search knowledge base
- `remember <title> <content>` — store to knowledge base
- `recall-recent [count]` — show recent entries

## Context
Part of making Quiet a viable alternative engine. Rag-memory needs to be accessible via simple bash commands rather than MCP tool calls, so it works consistently regardless of which engine is running.

## Test plan
- [ ] `recall "subscription auth"` returns results
- [ ] `remember "test" "test content"` stores successfully
- [ ] `recall-recent 3` shows recent entries