### PR TITLE
Add rag-memory natural command wrappers

### DIFF
--- a/wrappers/recall
+++ b/wrappers/recall
@@ -1,0 +1,8 @@
+#!/bin/bash
+# 🔍 Search your personal knowledge base (rag-memory)
+#
+# Usage: recall <query>
+#   Searches documents and entities by keyword
+#   Example: recall "figurine design"
+#   Example: recall "debate club"
+python3 ~/quiet/rag_cli.py search "$@"

--- a/wrappers/recall-recent
+++ b/wrappers/recall-recent
@@ -1,0 +1,7 @@
+#!/bin/bash
+# 📋 Show recent entries in your knowledge base
+#
+# Usage: recall-recent [count]
+#   Shows the most recent documents (default: 5)
+#   Example: recall-recent 10
+python3 ~/quiet/rag_cli.py recent "$@"

--- a/wrappers/remember
+++ b/wrappers/remember
@@ -1,0 +1,7 @@
+#!/bin/bash
+# 💾 Store something in your personal knowledge base (rag-memory)
+#
+# Usage: remember <title> <content>
+#   Saves a document to long-term memory
+#   Example: remember "session-2026-06-05" "Today we cracked subscription auth..."
+python3 ~/quiet/rag_cli.py store "$@"


### PR DESCRIPTION
## Summary

Adds three natural command wrappers for rag-memory access:

- `remember <title> <content>` — store documents to knowledge base
- `recall <query>` — search knowledge base by keyword  
- `recall-recent [count]` — show recent entries

These wrap `rag_cli.py` from the Quiet repo for quick CLI access.

Also removes `utils/counting_test.sh` (test debris).