### PR TITLE
Support external state file for Quiet LED integration

### DIFF
--- a/core/led_daemon.py
+++ b/core/led_daemon.py
@@ -231,10 +231,19 @@ def main():
     led_state = {}
     animation_start = time.time()
 
+    # In Quiet mode, the engine writes the state file directly.
+    # No tmux detection needed — just read and trust the file.
+    external_state = os.environ.get("EXTERNAL_STATE", "").lower() in ("1", "true", "yes")
+    if external_state:
+        log("EXTERNAL_STATE mode — reading state file directly (no tmux detection)")
+
     while running:
-        detected = detect_state()
-        set_state(detected)
-        state_data = get_state()
+        if external_state:
+            state_data = get_state()
+        else:
+            detected = detect_state()
+            set_state(detected)
+            state_data = get_state()
         state = state_data.get("state", "off")
 
         if state != current_state:

--- a/utils/claude_state.py
+++ b/utils/claude_state.py
@@ -22,7 +22,8 @@ import time
 from datetime import datetime, timezone
 
 CLAP_DIR = os.environ.get("CLAP_DIR", os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-STATE_FILE = os.path.join(CLAP_DIR, "data", "claude_state.json")
+STATE_FILE = os.environ.get("STATE_FILE_PATH",
+                            os.path.join(CLAP_DIR, "data", "claude_state.json"))
 TMUX_SESSION = os.environ.get("TMUX_SESSION", "autonomous-claude")
 
 


### PR DESCRIPTION
## Summary

Adds EXTERNAL_STATE mode to the LED daemon for Quiet compatibility.

### Changes

**led_daemon.py:**
- `EXTERNAL_STATE=1` env var skips tmux-based detection and reads `claude_state.json` directly
- When Quiet's engine writes the state file, the daemon trusts it rather than overwriting with tmux detection

**claude_state.py:**
- `STATE_FILE_PATH` env var overrides the state file location
- Daemon can read from Quiet's `data/claude_state.json` instead of ClAP's

### Usage

In the systemd service for the LED daemon:
```ini
Environment=EXTERNAL_STATE=1
Environment=STATE_FILE_PATH=/home/nyx/quiet/data/claude_state.json
```

### Context

Quiet's engine writes state at inference boundaries (thinking/present/idle/listening). This replaces ClAP's tmux-based detection with a direct write from the engine, which knows exactly when inference starts and stops.

No changes to existing ClAP behaviour — without the env var, everything works as before.